### PR TITLE
ci: integrate datadog metrics, add scheduled runs

### DIFF
--- a/.github/workflows/contract-analysis.yml
+++ b/.github/workflows/contract-analysis.yml
@@ -7,6 +7,8 @@ on:
       - develop
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   contract_analysis:

--- a/.github/workflows/contract-analysis.yml
+++ b/.github/workflows/contract-analysis.yml
@@ -12,4 +12,5 @@ jobs:
   contract_analysis:
     name: Shared
     uses: aurora-is-near/.github/.github/workflows/security_analysis.yml@master
-    secrets: inherit
+    secrets:
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}


### PR DESCRIPTION
## Description
PR integrates with shared workflow's datadog metrics by supplying an API key. Since this is a cross-org workflow call, secrets need to be explicitly stated. Also adds cron schedule for keeping a minimum one run daily that enables monitoring/alerting.