### PR TITLE
Fix borsh deserialization of pips and a few minor other fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 /res
+
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 /target
 /res
-
-.vscode

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -39,4 +39,5 @@ chrono = { workspace = true, features = ["now"] }
 
 [dev-dependencies]
 itertools.workspace = true
+near-sdk = { workspace = true, features = ["unit-testing"] }
 rstest.workspace = true

--- a/core/src/fees.rs
+++ b/core/src/fees.rs
@@ -215,10 +215,11 @@ pub struct FeeCollectorChangedEvent<'a> {
 impl BorshDeserialize for Pips {
     fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
         let pips: u32 = near_sdk::borsh::BorshDeserialize::deserialize_reader(reader)?;
-        let pips = Self::from_pips(pips).ok_or(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            format!("Invalid pips value: {pips}"),
-        ))?;
-        Ok(pips)
+        Self::from_pips(pips).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("{PipsOutOfRange} - Invalid pips value: {pips}"),
+            )
+        })
     }
 }

--- a/core/src/fees.rs
+++ b/core/src/fees.rs
@@ -5,7 +5,10 @@ use core::{
 use std::borrow::Cow;
 
 use defuse_num_utils::{CheckedAdd, CheckedMulDiv, CheckedSub};
-use near_sdk::{near, AccountId, AccountIdRef};
+use near_sdk::{
+    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    near, AccountId, AccountIdRef,
+};
 use thiserror::Error as ThisError;
 
 #[near(serializers = [borsh, json])]
@@ -16,9 +19,12 @@ pub struct FeesConfig {
 }
 
 /// 1 pip == 1/100th of bip == 0.0001%
-#[near(serializers = [borsh, json])]
+#[near(serializers = [json])]
 #[serde(try_from = "u32")]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, BorshSerialize, BorshSchema,
+)]
+#[borsh(crate = "::near_sdk::borsh")]
 pub struct Pips(u32);
 
 impl Pips {
@@ -204,4 +210,15 @@ pub struct FeeChangedEvent {
 pub struct FeeCollectorChangedEvent<'a> {
     pub old_fee_collector: Cow<'a, AccountIdRef>,
     pub new_fee_collector: Cow<'a, AccountIdRef>,
+}
+
+impl BorshDeserialize for Pips {
+    fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let pips: u32 = near_sdk::borsh::BorshDeserialize::deserialize_reader(reader)?;
+        let pips = Self::from_pips(pips).ok_or(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("Invalid pips value: {pips}"),
+        ))?;
+        Ok(pips)
+    }
 }

--- a/core/src/intents/mod.rs
+++ b/core/src/intents/mod.rs
@@ -47,10 +47,6 @@ pub enum Intent {
     TokenDiff(TokenDiff),
 }
 
-pub struct MetaIntent {
-    pub intent: Intent,
-}
-
 pub trait ExecutableIntent {
     fn execute_intent<S, I>(
         self,

--- a/core/src/intents/token_diff.rs
+++ b/core/src/intents/token_diff.rs
@@ -223,11 +223,11 @@ mod tests {
     fn closure_delta(
         #[values(
             (TokenId::Nep141("ft.near".parse().unwrap()), 1_000_000), (TokenId::Nep141("ft.near".parse().unwrap()), -1_000_000),
-            (TokenId::Nep171("nft.near".parse().unwrap(), "1".to_string()), 1), 
+            (TokenId::Nep171("nft.near".parse().unwrap(), "1".to_string()), 1),
             (TokenId::Nep171("nft.near".parse().unwrap(), "1".to_string()), -1),
             (TokenId::Nep245("mt.near".parse().unwrap(), "ft1".to_string()), 1_000_000),
             (TokenId::Nep245("mt.near".parse().unwrap(), "ft1".to_string()), -1_000_000),
-            (TokenId::Nep245("mt.near".parse().unwrap(), "nft1".to_string()), 1), 
+            (TokenId::Nep245("mt.near".parse().unwrap(), "nft1".to_string()), 1),
             (TokenId::Nep245("mt.near".parse().unwrap(), "nft1".to_string()), -1),
         )]
         token_delta: (TokenId, i128),

--- a/tests/src/tests/mod.rs
+++ b/tests/src/tests/mod.rs
@@ -1,2 +1,3 @@
 pub mod defuse;
 pub mod poa;
+pub mod utils;

--- a/tests/src/tests/utils.rs
+++ b/tests/src/tests/utils.rs
@@ -16,14 +16,14 @@ fn pips_borsch_serialization_back_and_forth() {
 
 #[rstest]
 #[trace]
-#[case(&[206, 137, 2, 0], 166350)]
-#[case(&[116, 38, 2, 0], 140916)]
-#[case(&[3, 186, 2, 0], 178691)]
-#[case(&[199, 66, 12, 0], 803527)]
-#[case(&[73, 131, 13, 0], 885577)]
-#[case(&[64, 66, 15, 0], 1000000)]
+#[case(&[206, 137, 2, 0], 166_350)]
+#[case(&[116, 38, 2, 0], 140_916)]
+#[case(&[3, 186, 2, 0], 178_691)]
+#[case(&[199, 66, 12, 0], 803_527)]
+#[case(&[73, 131, 13, 0], 885_577)]
+#[case(&[64, 66, 15, 0], 1_000_000)]
 #[case(&[0, 0, 0, 0], 0)]
 fn pip_borsch_deserialization_selected_values(#[case] serialized: &[u8], #[case] pips: u32) {
-    let deserialized: Pips = borsh::from_slice(&serialized).unwrap();
+    let deserialized: Pips = borsh::from_slice(serialized).unwrap();
     assert_eq!(deserialized, Pips::from_pips(pips).unwrap());
 }

--- a/tests/src/tests/utils.rs
+++ b/tests/src/tests/utils.rs
@@ -17,11 +17,17 @@ fn pips_borsch_serialization_back_and_forth() {
 #[rstest]
 #[trace]
 #[case(&[206, 137, 2, 0], 166_350)]
+#[trace]
 #[case(&[116, 38, 2, 0], 140_916)]
+#[trace]
 #[case(&[3, 186, 2, 0], 178_691)]
+#[trace]
 #[case(&[199, 66, 12, 0], 803_527)]
+#[trace]
 #[case(&[73, 131, 13, 0], 885_577)]
+#[trace]
 #[case(&[64, 66, 15, 0], 1_000_000)]
+#[trace]
 #[case(&[0, 0, 0, 0], 0)]
 fn pip_borsch_deserialization_selected_values(#[case] serialized: &[u8], #[case] pips: u32) {
     let deserialized: Pips = borsh::from_slice(serialized).unwrap();

--- a/tests/src/tests/utils.rs
+++ b/tests/src/tests/utils.rs
@@ -1,0 +1,29 @@
+use defuse::core::fees::Pips;
+use near_sdk::borsh;
+use rand::Rng;
+use rstest::rstest;
+
+#[test]
+fn pips_borsch_serialization_back_and_forth() {
+    // TODO: replace this with deterministic testing
+    let pip_val = rand::thread_rng().gen_range::<u32, _>(0..=Pips::MAX.as_pips());
+
+    let pip = Pips::from_pips(pip_val).unwrap();
+    let serialized = borsh::to_vec(&pip).unwrap();
+    let deserialized: Pips = borsh::from_slice(&serialized).unwrap();
+    assert_eq!(deserialized, pip);
+}
+
+#[rstest]
+#[trace]
+#[case(&[206, 137, 2, 0], 166350)]
+#[case(&[116, 38, 2, 0], 140916)]
+#[case(&[3, 186, 2, 0], 178691)]
+#[case(&[199, 66, 12, 0], 803527)]
+#[case(&[73, 131, 13, 0], 885577)]
+#[case(&[64, 66, 15, 0], 1000000)]
+#[case(&[0, 0, 0, 0], 0)]
+fn pip_borsch_deserialization_selected_values(#[case] serialized: &[u8], #[case] pips: u32) {
+    let deserialized: Pips = borsh::from_slice(&serialized).unwrap();
+    assert_eq!(deserialized, Pips::from_pips(pips).unwrap());
+}


### PR DESCRIPTION
Currently, the invariant of `Pips` (with a max value) can be broken through bad binary data. This fixes that.