### PR TITLE
Centralize randomness source and add test-utils with determinstic randomness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,9 +965,10 @@ dependencies = [
  "near-crypto 0.26.0",
  "near-sdk",
  "near-workspaces",
- "rand",
+ "randomness",
  "rstest",
  "serde_json",
+ "test-utils",
  "tokio",
 ]
 
@@ -3357,6 +3358,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "randomness"
+version = "0.1.0"
+dependencies = [
+ "rand",
+]
+
+[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4207,6 +4215,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test-utils"
+version = "0.1.0"
+dependencies = [
+ "rand_chacha",
+ "randomness",
+ "rstest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,10 @@ members = [
     "webauthn",
     "poa-factory",
     "poa-token",
+    "randomness",
     "serde-utils",
     "tests",
+    "test-utils",
     "wnear",
 ]
 default-members = ["defuse"]
@@ -49,6 +51,9 @@ defuse-poa-token.path = "poa-token"
 defuse-serde-utils.path = "serde-utils"
 defuse-wnear.path = "wnear"
 
+randomness.path = "randomness"
+test-utils.path = "test-utils"
+
 anyhow = "1"
 bnum = { version = "0.12", features = ["borsh"] }
 chrono = { version = "0.4", default-features = false }
@@ -64,6 +69,7 @@ near-plugins = { git = "https://github.com/Near-One/near-plugins", rev = "e6e4b0
 near-sdk = "5.7"
 near-workspaces = "0.14"
 p256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
+rand_chacha = "0.3"
 rstest = "0.21.0"
 serde_json = "1"
 serde_with = "3.9"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -39,4 +39,5 @@ chrono = { workspace = true, features = ["now"] }
 
 [dev-dependencies]
 itertools.workspace = true
+near-sdk = { workspace = true, features = ["unit-testing"] }
 rstest.workspace = true

--- a/core/src/intents/mod.rs
+++ b/core/src/intents/mod.rs
@@ -47,10 +47,6 @@ pub enum Intent {
     TokenDiff(TokenDiff),
 }
 
-pub struct MetaIntent {
-    pub intent: Intent,
-}
-
 pub trait ExecutableIntent {
     fn execute_intent<S, I>(
         self,

--- a/core/src/intents/token_diff.rs
+++ b/core/src/intents/token_diff.rs
@@ -223,11 +223,11 @@ mod tests {
     fn closure_delta(
         #[values(
             (TokenId::Nep141("ft.near".parse().unwrap()), 1_000_000), (TokenId::Nep141("ft.near".parse().unwrap()), -1_000_000),
-            (TokenId::Nep171("nft.near".parse().unwrap(), "1".to_string()), 1), 
+            (TokenId::Nep171("nft.near".parse().unwrap(), "1".to_string()), 1),
             (TokenId::Nep171("nft.near".parse().unwrap(), "1".to_string()), -1),
             (TokenId::Nep245("mt.near".parse().unwrap(), "ft1".to_string()), 1_000_000),
             (TokenId::Nep245("mt.near".parse().unwrap(), "ft1".to_string()), -1_000_000),
-            (TokenId::Nep245("mt.near".parse().unwrap(), "nft1".to_string()), 1), 
+            (TokenId::Nep245("mt.near".parse().unwrap(), "nft1".to_string()), 1),
             (TokenId::Nep245("mt.near".parse().unwrap(), "nft1".to_string()), -1),
         )]
         token_delta: (TokenId, i128),

--- a/randomness/Cargo.toml
+++ b/randomness/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "randomness"
+version = "0.1.0"
+edition.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+rand = "0.8"

--- a/randomness/src/lib.rs
+++ b/randomness/src/lib.rs
@@ -1,0 +1,26 @@
+pub use rand::prelude::SliceRandom;
+pub use rand::{seq, CryptoRng, Rng, RngCore, SeedableRng};
+
+pub mod distributions {
+    pub use rand::distributions::{
+        Alphanumeric, DistString, Distribution, Standard, WeightedIndex,
+    };
+    pub mod uniform {
+        pub use rand::distributions::uniform::SampleRange;
+    }
+}
+
+pub mod rngs {
+    pub use rand::rngs::mock::StepRng;
+    pub use rand::rngs::OsRng;
+}
+
+#[must_use]
+pub fn make_true_rng() -> impl Rng + CryptoRng {
+    rand::rngs::StdRng::from_entropy()
+}
+
+#[must_use]
+pub fn make_pseudo_rng() -> impl Rng {
+    rand::rngs::ThreadRng::default()
+}

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "test-utils"
+version = "0.1.0"
+edition.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+randomness.workspace = true
+rand_chacha.workspace = true
+rstest.workspace = true

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod random;

--- a/test-utils/src/random.rs
+++ b/test-utils/src/random.rs
@@ -6,20 +6,24 @@ use std::{num::ParseIntError, str::FromStr};
 pub struct Seed(pub u64);
 
 impl Seed {
+    #[must_use]
     pub fn from_entropy() -> Self {
         Seed(randomness::make_true_rng().r#gen::<u64>())
     }
 
+    #[must_use]
     pub fn from_entropy_and_print(test_name: &str) -> Self {
         let result = Seed(randomness::make_true_rng().r#gen::<u64>());
         result.print_with_decoration(test_name);
         result
     }
 
+    #[must_use]
     pub fn from_u64(v: u64) -> Self {
         Seed(v)
     }
 
+    #[must_use]
     pub fn as_u64(&self) -> u64 {
         self.0
     }
@@ -55,14 +59,16 @@ impl randomness::distributions::Distribution<Seed> for randomness::distributions
 pub struct TestRng(rand_chacha::ChaChaRng);
 
 impl TestRng {
+    #[must_use]
     pub fn new(seed: Seed) -> Self {
         Self(ChaChaRng::seed_from_u64(seed.as_u64()))
     }
 
+    #[must_use]
     pub fn random(rng: &mut (impl Rng + CryptoRng)) -> Self {
         Self::new(Seed(rng.r#gen()))
     }
-
+    #[must_use]
     pub fn from_entropy() -> Self {
         Self::new(Seed::from_entropy())
     }
@@ -78,7 +84,7 @@ impl RngCore for TestRng {
     }
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {
-        self.0.fill_bytes(dest)
+        self.0.fill_bytes(dest);
     }
 
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_chacha::rand_core::Error> {

--- a/test-utils/src/random.rs
+++ b/test-utils/src/random.rs
@@ -1,0 +1,101 @@
+use rand_chacha::ChaChaRng;
+pub use randomness::{self, seq::IteratorRandom, CryptoRng, Rng, RngCore, SeedableRng};
+use std::{num::ParseIntError, str::FromStr};
+
+#[derive(Debug, Copy, Clone)]
+pub struct Seed(pub u64);
+
+impl Seed {
+    pub fn from_entropy() -> Self {
+        Seed(randomness::make_true_rng().r#gen::<u64>())
+    }
+
+    pub fn from_entropy_and_print(test_name: &str) -> Self {
+        let result = Seed(randomness::make_true_rng().r#gen::<u64>());
+        result.print_with_decoration(test_name);
+        result
+    }
+
+    pub fn from_u64(v: u64) -> Self {
+        Seed(v)
+    }
+
+    pub fn as_u64(&self) -> u64 {
+        self.0
+    }
+
+    pub fn print_with_decoration(&self, test_name: &str) {
+        println!("{test_name} seed: {}", self.0);
+    }
+}
+
+impl FromStr for Seed {
+    type Err = ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let v = s.parse::<u64>()?;
+        Ok(Seed::from_u64(v))
+    }
+}
+
+impl From<u64> for Seed {
+    fn from(v: u64) -> Self {
+        Seed::from_u64(v)
+    }
+}
+
+impl randomness::distributions::Distribution<Seed> for randomness::distributions::Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Seed {
+        let new_seed = rng.r#gen::<u64>();
+        Seed::from_u64(new_seed)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TestRng(rand_chacha::ChaChaRng);
+
+impl TestRng {
+    pub fn new(seed: Seed) -> Self {
+        Self(ChaChaRng::seed_from_u64(seed.as_u64()))
+    }
+
+    pub fn random(rng: &mut (impl Rng + CryptoRng)) -> Self {
+        Self::new(Seed(rng.r#gen()))
+    }
+
+    pub fn from_entropy() -> Self {
+        Self::new(Seed::from_entropy())
+    }
+}
+
+impl RngCore for TestRng {
+    fn next_u32(&mut self) -> u32 {
+        self.0.next_u32()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.0.next_u64()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.0.fill_bytes(dest)
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_chacha::rand_core::Error> {
+        self.0.try_fill_bytes(dest)
+    }
+}
+
+impl CryptoRng for TestRng {}
+
+#[must_use]
+pub fn make_seedable_rng(seed: Seed) -> impl Rng + CryptoRng {
+    TestRng::new(seed)
+}
+
+pub fn gen_random_bytes(rng: &mut impl Rng, min_len: usize, max_len: usize) -> Vec<u8> {
+    let data_length = rng.gen_range(min_len..=max_len);
+    let mut bytes = vec![0; data_length];
+    rng.fill_bytes(&mut bytes);
+    bytes
+}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -18,7 +18,8 @@ near-crypto = "0.26"
 near-sdk = { workspace = true, features = ["unit-testing"] }
 near-workspaces.workspace = true
 near-contract-standards.workspace = true
-rand = "0.8"
+randomness.workspace = true
 rstest.workspace = true
 serde_json.workspace = true
+test-utils.workspace = true
 tokio = { workspace = true, features = ["macros"] }

--- a/tests/src/tests/defuse/intents/ft_withdraw.rs
+++ b/tests/src/tests/defuse/intents/ft_withdraw.rs
@@ -10,7 +10,7 @@ use defuse::{
     },
 };
 use near_sdk::{AccountId, NearToken};
-use rand::{thread_rng, Rng};
+use randomness::{make_true_rng, Rng};
 
 use super::ExecuteIntentsExt;
 use crate::{
@@ -34,7 +34,7 @@ async fn test_ft_withdraw_intent() {
     env.defuse
         .execute_intents([env.user1.sign_defuse_message(
             env.defuse.id(),
-            thread_rng().gen(),
+            make_true_rng().gen(),
             Deadline::timeout(Duration::from_secs(120)),
             DefuseIntents {
                 intents: [FtWithdraw {
@@ -69,7 +69,7 @@ async fn test_ft_withdraw_intent() {
     env.defuse
         .execute_intents([env.user1.sign_defuse_message(
             env.defuse.id(),
-            thread_rng().gen(),
+            make_true_rng().gen(),
             Deadline::MAX,
             DefuseIntents {
                 intents: [FtWithdraw {
@@ -121,7 +121,7 @@ async fn test_ft_withdraw_intent() {
         env.defuse.id(),
         [env.user1.sign_defuse_message(
             env.defuse.id(),
-            thread_rng().gen(),
+            make_true_rng().gen(),
             Deadline::MAX,
             DefuseIntents {
                 intents: [FtWithdraw {
@@ -206,7 +206,7 @@ async fn test_ft_withdraw_intent_msg() {
     env.defuse
         .execute_intents([env.user1.sign_defuse_message(
             env.defuse.id(),
-            thread_rng().gen(),
+            make_true_rng().gen(),
             Deadline::timeout(Duration::from_secs(120)),
             DefuseIntents {
                 intents: [FtWithdraw {

--- a/tests/src/tests/defuse/intents/mod.rs
+++ b/tests/src/tests/defuse/intents/mod.rs
@@ -8,7 +8,7 @@ use defuse::{
     intents::SimulationOutput,
 };
 use near_sdk::{AccountId, AccountIdRef};
-use rand::{thread_rng, Rng};
+use randomness::{make_true_rng, Rng};
 use serde_json::json;
 
 use crate::utils::mt::MtExt;
@@ -150,7 +150,7 @@ async fn test_simulate_is_view_method() {
     env.defuse
         .simulate_intents([env.user1.sign_defuse_message(
             env.defuse.id(),
-            thread_rng().gen(),
+            make_true_rng().gen(),
             Deadline::MAX,
             DefuseIntents {
                 intents: [Transfer {

--- a/tests/src/tests/defuse/intents/token_diff.rs
+++ b/tests/src/tests/defuse/intents/token_diff.rs
@@ -12,7 +12,7 @@ use defuse::core::{
 };
 use near_sdk::AccountId;
 use near_workspaces::Account;
-use rand::{thread_rng, Rng};
+use randomness::{make_true_rng, Rng};
 use rstest::rstest;
 
 use crate::{
@@ -193,7 +193,7 @@ async fn test_ft_diffs(env: &Env, accounts: Vec<AccountFtDiff<'_>>) {
             account.diff.iter().cloned().map(|diff| {
                 account.account.sign_defuse_message(
                     env.defuse.id(),
-                    thread_rng().gen(),
+                    make_true_rng().gen(),
                     Deadline::timeout(Duration::from_secs(120)),
                     DefuseIntents {
                         intents: [TokenDiff {
@@ -259,7 +259,7 @@ async fn test_invariant_violated() {
     let signed: Vec<_> = [
         env.user1.sign_defuse_message(
             env.defuse.id(),
-            thread_rng().gen(),
+            make_true_rng().gen(),
             Deadline::MAX,
             DefuseIntents {
                 intents: [TokenDiff {
@@ -275,7 +275,7 @@ async fn test_invariant_violated() {
         ),
         env.user1.sign_defuse_message(
             env.defuse.id(),
-            thread_rng().gen(),
+            make_true_rng().gen(),
             Deadline::MAX,
             DefuseIntents {
                 intents: [TokenDiff {
@@ -366,7 +366,7 @@ async fn test_solver_user_closure(
     // solver signs his intent
     let solver_commitment = solver.sign_defuse_message(
         env.defuse.id(),
-        thread_rng().gen(),
+        make_true_rng().gen(),
         Deadline::timeout(Duration::from_secs(90)),
         DefuseIntents {
             intents: [TokenDiff {
@@ -424,7 +424,7 @@ async fn test_solver_user_closure(
     // user signs the message
     let user_commitment = user.sign_defuse_message(
         env.defuse.id(),
-        thread_rng().gen(),
+        make_true_rng().gen(),
         Deadline::timeout(Duration::from_secs(90)),
         DefuseIntents {
             intents: [TokenDiff {

--- a/tests/src/tests/defuse/tokens/nep141.rs
+++ b/tests/src/tests/defuse/tokens/nep141.rs
@@ -10,7 +10,7 @@ use defuse::{
     tokens::DepositMessage,
 };
 use near_sdk::{json_types::U128, AccountId, NearToken};
-use rand::{thread_rng, Rng};
+use randomness::{make_true_rng, Rng};
 use serde_json::json;
 
 use crate::{
@@ -116,7 +116,7 @@ async fn test_deposit_withdraw_intent() {
                     receiver_id: env.user1.id().clone(),
                     execute_intents: [env.user1.sign_defuse_message(
                         env.defuse.id(),
-                        thread_rng().gen(),
+                        make_true_rng().gen(),
                         Deadline::timeout(Duration::from_secs(120)),
                         DefuseIntents {
                             intents: [
@@ -198,7 +198,7 @@ async fn test_deposit_withdraw_intent_refund() {
                     receiver_id: env.user1.id().clone(),
                     execute_intents: [env.user1.sign_defuse_message(
                         env.defuse.id(),
-                        thread_rng().gen(),
+                        make_true_rng().gen(),
                         Deadline::MAX,
                         DefuseIntents {
                             intents: [FtWithdraw {

--- a/tests/src/tests/defuse/upgrade.rs
+++ b/tests/src/tests/defuse/upgrade.rs
@@ -1,6 +1,6 @@
 use defuse::core::crypto::PublicKey;
 use near_sdk::AccountId;
-use rand::{thread_rng, Rng};
+use randomness::{make_true_rng, Rng};
 
 use crate::{tests::defuse::accounts::AccountManagerExt, utils::mt::MtExt};
 
@@ -43,9 +43,9 @@ async fn test_upgrade() {
     );
 
     for public_key in [
-        PublicKey::Ed25519(thread_rng().gen()),
-        PublicKey::Secp256k1(thread_rng().gen()),
-        PublicKey::P256(thread_rng().gen()),
+        PublicKey::Ed25519(make_true_rng().gen()),
+        PublicKey::Secp256k1(make_true_rng().gen()),
+        PublicKey::P256(make_true_rng().gen()),
     ] {
         assert!(new_contract
             .has_public_key(&public_key.to_implicit_account_id(), &public_key)

--- a/tests/src/tests/mod.rs
+++ b/tests/src/tests/mod.rs
@@ -1,2 +1,3 @@
 pub mod defuse;
 pub mod poa;
+pub mod utils;

--- a/tests/src/tests/utils.rs
+++ b/tests/src/tests/utils.rs
@@ -1,0 +1,35 @@
+use defuse::core::fees::Pips;
+use near_sdk::borsh;
+use rand::Rng;
+use rstest::rstest;
+
+#[test]
+fn pips_borsch_serialization_back_and_forth() {
+    // TODO: replace this with deterministic testing
+    let pip_val = rand::thread_rng().gen_range::<u32, _>(0..=Pips::MAX.as_pips());
+
+    let pip = Pips::from_pips(pip_val).unwrap();
+    let serialized = borsh::to_vec(&pip).unwrap();
+    let deserialized: Pips = borsh::from_slice(&serialized).unwrap();
+    assert_eq!(deserialized, pip);
+}
+
+#[rstest]
+#[trace]
+#[case(&[206, 137, 2, 0], 166_350)]
+#[trace]
+#[case(&[116, 38, 2, 0], 140_916)]
+#[trace]
+#[case(&[3, 186, 2, 0], 178_691)]
+#[trace]
+#[case(&[199, 66, 12, 0], 803_527)]
+#[trace]
+#[case(&[73, 131, 13, 0], 885_577)]
+#[trace]
+#[case(&[64, 66, 15, 0], 1_000_000)]
+#[trace]
+#[case(&[0, 0, 0, 0], 0)]
+fn pip_borsch_deserialization_selected_values(#[case] serialized: &[u8], #[case] pips: u32) {
+    let deserialized: Pips = borsh::from_slice(serialized).unwrap();
+    assert_eq!(deserialized, Pips::from_pips(pips).unwrap());
+}

--- a/tests/src/tests/utils.rs
+++ b/tests/src/tests/utils.rs
@@ -1,12 +1,14 @@
 use defuse::core::fees::Pips;
 use near_sdk::borsh;
-use rand::Rng;
+use randomness::Rng;
 use rstest::rstest;
+use test_utils::random::{make_seedable_rng, Seed};
 
-#[test]
-fn pips_borsch_serialization_back_and_forth() {
-    // TODO: replace this with deterministic testing
-    let pip_val = rand::thread_rng().gen_range::<u32, _>(0..=Pips::MAX.as_pips());
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn pips_borsch_serialization_back_and_forth(#[case] seed: Seed) {
+    let pip_val = make_seedable_rng(seed).gen_range::<u32, _>(0..=Pips::MAX.as_pips());
 
     let pip = Pips::from_pips(pip_val).unwrap();
     let serialized = borsh::to_vec(&pip).unwrap();


### PR DESCRIPTION
1. Randomness shall from now on be taken from the `randomness` crate. This makes it easier to understand the source of randomness, instead of the plethora of options in `rand`.

2. Tests now can be randomized using the `test-utils` crate.