### PR TITLE
Version crates from workspace except for defuse, poa token and poa factory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ default-members = ["defuse"]
 [workspace.package]
 edition = "2024"
 repository = "https://github.com/defuse-protocol/defuse-contracts"
+version = "0.1.0"
 
 [workspace.dependencies]
 defuse-admin-utils.path = "admin-utils"

--- a/admin-utils/Cargo.toml
+++ b/admin-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "defuse-admin-utils"
 edition.workspace = true
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 near-sdk.workspace = true

--- a/bitmap/Cargo.toml
+++ b/bitmap/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "defuse-bitmap"
 edition.workspace = true
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 defuse-map-utils.workspace = true

--- a/borsh-utils/Cargo.toml
+++ b/borsh-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "defuse-borsh-utils"
 edition.workspace = true
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 near-sdk.workspace = true

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "defuse-controller"
 edition.workspace = true
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 near-sdk.workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "defuse-core"
 edition.workspace = true
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 defuse-bitmap.workspace = true

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "defuse-crypto"
 edition.workspace = true
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 ed25519-dalek.workspace = true

--- a/erc191/Cargo.toml
+++ b/erc191/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "defuse-erc191"
 edition.workspace = true
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 defuse-crypto = { workspace = true, features = ["serde"] }

--- a/map-utils/Cargo.toml
+++ b/map-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "defuse-map-utils"
 edition.workspace = true
-version = "0.1.0"
+version.workspace = true
 
 [lib]
 doctest = true

--- a/near-utils/Cargo.toml
+++ b/near-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "defuse-near-utils"
 edition.workspace = true
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 near-sdk.workspace = true

--- a/nep245/Cargo.toml
+++ b/nep245/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "defuse-nep245"
 edition.workspace = true
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 derive_more.workspace = true

--- a/nep413/Cargo.toml
+++ b/nep413/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "defuse-nep413"
 edition.workspace = true
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 defuse-crypto = { workspace = true, features = ["serde"] }

--- a/nep461/Cargo.toml
+++ b/nep461/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
 name = "defuse-nep461"
 edition.workspace = true
-version = "0.1.0"
+version.workspace = true

--- a/num-utils/Cargo.toml
+++ b/num-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "defuse-num-utils"
 edition.workspace = true
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 bnum.workspace = true

--- a/randomness/Cargo.toml
+++ b/randomness/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "randomness"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 
 [lints]

--- a/serde-utils/Cargo.toml
+++ b/serde-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "defuse-serde-utils"
 edition.workspace = true
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 derive_more = { workspace = true, features = ["from"] }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-utils"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 
 [lints]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "defuse-tests"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 
 [lints]

--- a/webauthn/Cargo.toml
+++ b/webauthn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "defuse-webauthn"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 
 [lints]

--- a/wnear/Cargo.toml
+++ b/wnear/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "defuse-wnear"
 edition.workspace = true
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 near-contract-standards.workspace = true


### PR DESCRIPTION
As discussed, in this PR we version things with these rules:

1. PoA token has its own version number
2. PoA factory has its own version number
3. Defuse has its own version number
4. Everything else uses the workspace version number