### PR TITLE
Add assert_error_contains in a trait to properly check for error string contents

### DIFF
--- a/test-utils/src/asserts.rs
+++ b/test-utils/src/asserts.rs
@@ -10,7 +10,7 @@ where
 {
     fn assert_error_contains(&self, to_contain: &str) {
         match self {
-            Ok(_) => panic!("unwrap_err() with Ok() result"),
+            Ok(_) => panic!("Result::unwrap_err() on Result::Ok()"),
             Err(e) => {
                 // Define the env var to check strings in errors
                 let check_string = std::env::var(DISABLE_STRING_CHECKS_ENV_VAR).is_err();
@@ -18,7 +18,7 @@ where
                     let error_string = e.to_string();
                     assert!(
                         e.to_string().contains(to_contain),
-                        "unwrap_err() successful, but the error string does not contain the expected string.\nError string: `{error_string}`\nshould have contained: `{to_contain}`"
+                        "Result::unwrap_err() successful, but the error string does not contain the expected string.\nError string: `{error_string}`\nshould have contained: `{to_contain}`"
                     );
                 } else {
                     eprintln!(

--- a/test-utils/src/asserts.rs
+++ b/test-utils/src/asserts.rs
@@ -1,4 +1,4 @@
-use std::cell::LazyCell;
+use std::{cell::LazyCell, fmt::Display};
 
 const DISABLE_STRING_CHECKS_ENV_VAR: &str = "DEFUSE_SKIP_STRING_ERROR_CHECKS";
 
@@ -14,7 +14,7 @@ pub trait ResultAssertsExt {
 
 impl<T, E> ResultAssertsExt for Result<T, E>
 where
-    E: ToString,
+    E: Display,
 {
     fn assert_err_contains(&self, to_contain: &str) {
         match self {

--- a/test-utils/src/asserts.rs
+++ b/test-utils/src/asserts.rs
@@ -1,7 +1,7 @@
 const DISABLE_STRING_CHECKS_ENV_VAR: &str = "DEFUSE_SKIP_STRING_ERROR_CHECKS";
 
 pub trait ResultAssertsExt {
-    fn assert_error_contains(&self, s: &str);
+    fn assert_error_contains(&self, to_contain: &str);
 }
 
 impl<T, E> ResultAssertsExt for Result<T, E>

--- a/test-utils/src/asserts.rs
+++ b/test-utils/src/asserts.rs
@@ -1,0 +1,31 @@
+const DISABLE_STRING_CHECKS_ENV_VAR: &str = "DEFUSE_SKIP_STRING_ERROR_CHECKS";
+
+pub trait ResultAssertsExt {
+    fn assert_error_contains(&self, s: &str);
+}
+
+impl<T, E> ResultAssertsExt for Result<T, E>
+where
+    E: ToString,
+{
+    fn assert_error_contains(&self, to_contain: &str) {
+        match self {
+            Ok(_) => panic!("unwrap_err() with Ok() result"),
+            Err(e) => {
+                // Define the env var to check strings in errors
+                let check_string = std::env::var(DISABLE_STRING_CHECKS_ENV_VAR).is_err();
+                if check_string {
+                    let error_string = e.to_string();
+                    assert!(
+                        e.to_string().contains(to_contain),
+                        "unwrap_err() successful, but the error string does not contain the expected string.\nError string: `{error_string}`\nshould have contained: `{to_contain}`"
+                    );
+                } else {
+                    eprintln!(
+                        "WARNING: Ignoring string contents' checks in errors due to env var `{DISABLE_STRING_CHECKS_ENV_VAR}` being defined"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/test-utils/src/asserts.rs
+++ b/test-utils/src/asserts.rs
@@ -1,19 +1,27 @@
+use std::cell::LazyCell;
+
 const DISABLE_STRING_CHECKS_ENV_VAR: &str = "DEFUSE_SKIP_STRING_ERROR_CHECKS";
 
+thread_local! {
+    static DISABLE_STRING_CHECKS: LazyCell<bool> = LazyCell::new(
+        || std::env::var(DISABLE_STRING_CHECKS_ENV_VAR).is_ok(),
+    );
+}
+
 pub trait ResultAssertsExt {
-    fn assert_error_contains(&self, to_contain: &str);
+    fn assert_err_contains(&self, to_contain: &str);
 }
 
 impl<T, E> ResultAssertsExt for Result<T, E>
 where
     E: ToString,
 {
-    fn assert_error_contains(&self, to_contain: &str) {
+    fn assert_err_contains(&self, to_contain: &str) {
         match self {
             Ok(_) => panic!("Result::unwrap_err() on Result::Ok()"),
             Err(e) => {
                 // Define the env var to check strings in errors
-                let check_string = std::env::var(DISABLE_STRING_CHECKS_ENV_VAR).is_err();
+                let check_string = !DISABLE_STRING_CHECKS.with(|b| **b);
                 if check_string {
                     let error_string = e.to_string();
                     assert!(

--- a/test-utils/src/asserts.rs
+++ b/test-utils/src/asserts.rs
@@ -16,6 +16,7 @@ impl<T, E> ResultAssertsExt for Result<T, E>
 where
     E: Display,
 {
+    #[track_caller]
     fn assert_err_contains(&self, to_contain: impl AsRef<str>) {
         let to_contain = to_contain.as_ref();
         match self {

--- a/test-utils/src/asserts.rs
+++ b/test-utils/src/asserts.rs
@@ -9,14 +9,15 @@ thread_local! {
 }
 
 pub trait ResultAssertsExt {
-    fn assert_err_contains(&self, to_contain: &str);
+    fn assert_err_contains(&self, to_contain: impl AsRef<str>);
 }
 
 impl<T, E> ResultAssertsExt for Result<T, E>
 where
     E: Display,
 {
-    fn assert_err_contains(&self, to_contain: &str) {
+    fn assert_err_contains(&self, to_contain: impl AsRef<str>) {
+        let to_contain = to_contain.as_ref();
         match self {
             Ok(_) => panic!("Result::unwrap_err() on Result::Ok()"),
             Err(e) => {

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod asserts;
 pub mod random;

--- a/tests/src/tests/defuse/intents/relayers.rs
+++ b/tests/src/tests/defuse/intents/relayers.rs
@@ -41,13 +41,13 @@ async fn test_relayer_keys(#[values(false, true)] no_registration: bool) {
     )
     .execute_intents([]) // Empty because it's just to ensure that authorization works/doesn't work
     .await
-    .assert_error_contains("Failed to query access key");
+    .assert_err_contains("Failed to query access key");
 
     // A random, unauthorized user attempts to add a key (no role `Role::RelayerKeysManager`) and fails
     env.user2
         .add_relayer_key(env.defuse.id(), &new_relayer_public_key_near_sdk)
         .await
-        .assert_error_contains("Requires one of these roles:");
+        .assert_err_contains("Requires one of these roles:");
 
     // A `Role::RelayerKeysManager` attempts to add the key, successfully
     env.user1
@@ -60,7 +60,7 @@ async fn test_relayer_keys(#[values(false, true)] no_registration: bool) {
     env.user1
         .add_relayer_key(env.defuse.id(), &new_relayer_public_key_near_sdk)
         .await
-        .assert_error_contains("key already exists");
+        .assert_err_contains("key already exists");
 
     // Create a Function-call Key, then use it to execute an (empty) intent
     Contract::from_secret_key(
@@ -76,7 +76,7 @@ async fn test_relayer_keys(#[values(false, true)] no_registration: bool) {
     env.user2
         .delete_relayer_key(env.defuse.id(), &new_relayer_public_key_near_sdk)
         .await
-        .assert_error_contains("Requires one of these roles:");
+        .assert_err_contains("Requires one of these roles:");
 
     // Delete the relayer key by the authorized entity
     env.user1
@@ -89,7 +89,7 @@ async fn test_relayer_keys(#[values(false, true)] no_registration: bool) {
     env.user1
         .delete_relayer_key(env.defuse.id(), &new_relayer_public_key_near_sdk)
         .await
-        .assert_error_contains("key not found");
+        .assert_err_contains("key not found");
 
     let access_keys = env.defuse.view_access_keys().await.unwrap();
     dbg!(&access_keys);


### PR DESCRIPTION
The contents of errors in strings can be checked. If the env var `DEFUSE_SKIP_STRING_ERROR_CHECKS` is defined, only `unwrap_err()` is checked.