### PR TITLE
Use defuse version from ctl-intents.near, and bump it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "defuse"
-version = "0.1.0"
+version = "0.2.4"
 dependencies = [
  "bnum",
  "defuse-admin-utils",

--- a/defuse/Cargo.toml
+++ b/defuse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "defuse"
-version = "0.1.0"
+version = "0.2.4"
 edition.workspace = true
 repository.workspace = true
 


### PR DESCRIPTION
Set the current version of defuse from ctl-intents.near, and bump it. The current version is: 0.2.3, so this one is 0.2.4.

https://nearblocks.io/address/ctl-intents.near?tab=contract

The current version can be retrieved using the function `get_latest_release_hash`, followed by `get_releases`, which leads to the current release being 0.2.3.

