### PR TITLE
Add security analysis to regular CI on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,3 +148,9 @@ jobs:
       - name: Run security audit
         run: cargo audit --deny unsound --deny yanked
         # run: cargo audit --deny warnings  # Warnings include: unmaintained, unsound and yanked
+
+  contract_analysis:
+    name: Shared security analysis
+    uses: aurora-is-near/.github/.github/workflows/security_analysis.yml@master
+    secrets:
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}

--- a/core/src/engine/state/cached.rs
+++ b/core/src/engine/state/cached.rs
@@ -108,7 +108,7 @@ where
     #[must_use]
     fn add_public_key(&mut self, account_id: AccountId, public_key: PublicKey) -> bool {
         let had = self.has_public_key(&account_id, &public_key);
-        let account = self.accounts.get_or_create(account_id.clone());
+        let account = self.accounts.get_or_create(account_id);
         if had {
             account.public_keys_removed.remove(&public_key)
         } else {
@@ -119,7 +119,7 @@ where
     #[must_use]
     fn remove_public_key(&mut self, account_id: AccountId, public_key: PublicKey) -> bool {
         let had = self.has_public_key(&account_id, &public_key);
-        let account = self.accounts.get_or_create(account_id.clone());
+        let account = self.accounts.get_or_create(account_id);
         if had {
             account.public_keys_removed.insert(public_key)
         } else {

--- a/core/src/engine/state/deltas.rs
+++ b/core/src/engine/state/deltas.rs
@@ -523,9 +523,9 @@ mod tests {
             deltas.finalize().unwrap_err(),
             InvariantViolated::UnmatchedDeltas {
                 unmatched_deltas: TokenDeltas::default()
-                    .with_apply_delta(ft1.clone(), -3)
+                    .with_apply_delta(ft1, -3)
                     .unwrap()
-                    .with_apply_delta(ft2.clone(), -1)
+                    .with_apply_delta(ft2, -1)
                     .unwrap()
             }
         );

--- a/core/src/intents/token_diff.rs
+++ b/core/src/intents/token_diff.rs
@@ -337,10 +337,10 @@ mod tests {
                     .with_apply_deltas([(t1.clone(), -100), (t2.clone(), 200)])
                     .unwrap(),
                 TokenDeltas::default()
-                    .with_apply_deltas([(t2.clone(), -200), (t3.clone(), 300)])
+                    .with_apply_deltas([(t2, -200), (t3.clone(), 300)])
                     .unwrap(),
                 TokenDeltas::default()
-                    .with_apply_deltas([(t3.clone(), -300), (t1.clone(), 101)])
+                    .with_apply_deltas([(t3, -300), (t1, 101)])
                     .unwrap(),
             ]
             .into_iter()

--- a/core/src/payload/mod.rs
+++ b/core/src/payload/mod.rs
@@ -51,7 +51,7 @@ impl<T> ExtractDefusePayload<T> for DefusePayload<T> {
     type Error = Infallible;
 
     #[inline]
-    fn extract_defuse_payload(self) -> Result<DefusePayload<T>, Self::Error> {
+    fn extract_defuse_payload(self) -> Result<Self, Self::Error> {
         Ok(self)
     }
 }

--- a/core/src/tokens.rs
+++ b/core/src/tokens.rs
@@ -428,12 +428,7 @@ mod tests {
 
         assert!(
             Amounts::<BTreeMap<_, i128>>::default()
-                .with_apply_deltas([
-                    (t1.clone(), 1),
-                    (t1.clone(), -1),
-                    (t2.clone(), -1),
-                    (t2.clone(), 1)
-                ])
+                .with_apply_deltas([(t1.clone(), 1), (t1, -1), (t2.clone(), -1), (t2, 1)])
                 .unwrap()
                 .is_empty()
         );

--- a/defuse/src/contract/intents/relayer.rs
+++ b/defuse/src/contract/intents/relayer.rs
@@ -28,10 +28,7 @@ impl RelayerKeys for Contract {
 
     #[private]
     fn do_add_relayer_key(&mut self, public_key: PublicKey) {
-        require!(
-            self.relayer_keys.insert(public_key.clone()),
-            "key already exists",
-        );
+        require!(self.relayer_keys.insert(public_key), "key already exists",);
     }
 
     #[pause(name = "intents")]

--- a/defuse/src/contract/intents/state.rs
+++ b/defuse/src/contract/intents/state.rs
@@ -173,8 +173,8 @@ impl State for Contract {
             .near_withdraw(U128(withdraw.amount.as_yoctonear()))
             .then(
                 // do_native_withdraw only after unwrapping NEAR
-                Contract::ext(CURRENT_ACCOUNT_ID.clone())
-                    .with_static_gas(Contract::DO_NATIVE_WITHDRAW_GAS)
+                Self::ext(CURRENT_ACCOUNT_ID.clone())
+                    .with_static_gas(Self::DO_NATIVE_WITHDRAW_GAS)
                     .do_native_withdraw(withdraw),
             );
 
@@ -202,8 +202,8 @@ impl State for Contract {
             .near_withdraw(U128(storage_deposit.amount.as_yoctonear()))
             .then(
                 // do_storage_deposit only after unwrapping NEAR
-                Contract::ext(CURRENT_ACCOUNT_ID.clone())
-                    .with_static_gas(Contract::DO_STORAGE_DEPOSIT_GAS)
+                Self::ext(CURRENT_ACCOUNT_ID.clone())
+                    .with_static_gas(Self::DO_STORAGE_DEPOSIT_GAS)
                     .do_storage_deposit(storage_deposit),
             );
 

--- a/defuse/src/contract/mod.rs
+++ b/defuse/src/contract/mod.rs
@@ -73,6 +73,7 @@ pub struct Contract {
 impl Contract {
     #[must_use]
     #[init]
+    #[allow(clippy::use_self)] // Clippy seems to not play well with near-sdk, or there is a bug in clippy - seen in shared security analysis
     pub fn new(config: DefuseConfig) -> Self {
         let mut contract = Self {
             accounts: Accounts::new(Prefix::Accounts),

--- a/defuse/src/contract/tokens/nep141/withdraw.rs
+++ b/defuse/src/contract/tokens/nep141/withdraw.rs
@@ -80,8 +80,8 @@ impl Contract {
                 .near_withdraw(U128(storage_deposit.as_yoctonear()))
                 .then(
                     // schedule storage_deposit() only after near_withdraw() returns
-                    Contract::ext(CURRENT_ACCOUNT_ID.clone())
-                        .with_static_gas(Contract::DO_FT_WITHDRAW_GAS.saturating_add(if is_call {
+                    Self::ext(CURRENT_ACCOUNT_ID.clone())
+                        .with_static_gas(Self::DO_FT_WITHDRAW_GAS.saturating_add(if is_call {
                             FT_TRANSFER_CALL_GAS
                         } else {
                             FT_TRANSFER_GAS
@@ -89,11 +89,11 @@ impl Contract {
                         .do_ft_withdraw(withdraw.clone()),
                 )
         } else {
-            Contract::do_ft_withdraw(withdraw.clone())
+            Self::do_ft_withdraw(withdraw.clone())
         }
         .then(
-            Contract::ext(CURRENT_ACCOUNT_ID.clone())
-                .with_static_gas(Contract::FT_RESOLVE_WITHDRAW_GAS)
+            Self::ext(CURRENT_ACCOUNT_ID.clone())
+                .with_static_gas(Self::FT_RESOLVE_WITHDRAW_GAS)
                 .ft_resolve_withdraw(withdraw.token, owner_id, withdraw.amount, is_call),
         )
         .into())

--- a/defuse/src/contract/tokens/nep171/withdraw.rs
+++ b/defuse/src/contract/tokens/nep171/withdraw.rs
@@ -82,8 +82,8 @@ impl Contract {
                 .near_withdraw(U128(storage_deposit.as_yoctonear()))
                 .then(
                     // schedule storage_deposit() only after near_withdraw() returns
-                    Contract::ext(CURRENT_ACCOUNT_ID.clone())
-                        .with_static_gas(Contract::DO_NFT_WITHDRAW_GAS.saturating_add(if is_call {
+                    Self::ext(CURRENT_ACCOUNT_ID.clone())
+                        .with_static_gas(Self::DO_NFT_WITHDRAW_GAS.saturating_add(if is_call {
                             NFT_TRANSFER_CALL_GAS
                         } else {
                             NFT_TRANSFER_GAS
@@ -91,11 +91,11 @@ impl Contract {
                         .do_nft_withdraw(withdraw.clone()),
                 )
         } else {
-            Contract::do_nft_withdraw(withdraw.clone())
+            Self::do_nft_withdraw(withdraw.clone())
         }
         .then(
-            Contract::ext(CURRENT_ACCOUNT_ID.clone())
-                .with_static_gas(Contract::NFT_RESOLVE_WITHDRAW_GAS)
+            Self::ext(CURRENT_ACCOUNT_ID.clone())
+                .with_static_gas(Self::NFT_RESOLVE_WITHDRAW_GAS)
                 .nft_resolve_withdraw(withdraw.token, owner_id, withdraw.token_id, is_call),
         )
         .into())

--- a/defuse/src/contract/tokens/nep245/core.rs
+++ b/defuse/src/contract/tokens/nep245/core.rs
@@ -234,7 +234,7 @@ impl Contract {
                 msg,
             )
             .then(
-                Contract::ext(CURRENT_ACCOUNT_ID.clone())
+                Self::ext(CURRENT_ACCOUNT_ID.clone())
                     .with_static_gas(MT_RESOLVE_TRANSFER_GAS)
                     .mt_resolve_transfer(previous_owner_ids, receiver_id, token_ids, amounts, None),
             )

--- a/defuse/src/contract/tokens/nep245/withdraw.rs
+++ b/defuse/src/contract/tokens/nep245/withdraw.rs
@@ -89,8 +89,8 @@ impl Contract {
                 .near_withdraw(U128(storage_deposit.as_yoctonear()))
                 .then(
                     // schedule storage_deposit() only after near_withdraw() returns
-                    Contract::ext(CURRENT_ACCOUNT_ID.clone())
-                        .with_static_gas(Contract::DO_MT_WITHDRAW_GAS.saturating_add(if is_call {
+                    Self::ext(CURRENT_ACCOUNT_ID.clone())
+                        .with_static_gas(Self::DO_MT_WITHDRAW_GAS.saturating_add(if is_call {
                             MT_BATCH_TRANSFER_CALL_GAS
                         } else {
                             MT_BATCH_TRANSFER_GAS
@@ -98,11 +98,11 @@ impl Contract {
                         .do_mt_withdraw(withdraw.clone()),
                 )
         } else {
-            Contract::do_mt_withdraw(withdraw.clone())
+            Self::do_mt_withdraw(withdraw.clone())
         }
         .then(
-            Contract::ext(CURRENT_ACCOUNT_ID.clone())
-                .with_static_gas(Contract::MT_RESOLVE_WITHDRAW_GAS)
+            Self::ext(CURRENT_ACCOUNT_ID.clone())
+                .with_static_gas(Self::MT_RESOLVE_WITHDRAW_GAS)
                 .mt_resolve_withdraw(
                     withdraw.token,
                     owner_id,

--- a/defuse/src/tokens/mod.rs
+++ b/defuse/src/tokens/mod.rs
@@ -45,7 +45,7 @@ impl DepositMessage {
 
     #[must_use]
     #[inline]
-    pub fn with_refund_if_fails(mut self) -> Self {
+    pub const fn with_refund_if_fails(mut self) -> Self {
         self.refund_if_fails = true;
         self
     }

--- a/map-utils/src/cleanup.rs
+++ b/map-utils/src/cleanup.rs
@@ -218,7 +218,7 @@ where
     E: OccupiedEntry<'a, V: Default + Eq>,
 {
     #[inline]
-    pub fn new(entry: E) -> Self {
+    pub const fn new(entry: E) -> Self {
         Self(Some(entry), PhantomData)
     }
 

--- a/map-utils/src/cleanup.rs
+++ b/map-utils/src/cleanup.rs
@@ -1,3 +1,7 @@
+// This is due to a bug in clippy that happens with shared security analysis
+// Clippy doesn't seem to play well with autoimpl
+#![allow(clippy::type_repetition_in_bounds)]
+
 use core::{
     fmt::Debug,
     marker::PhantomData,

--- a/nep413/src/lib.rs
+++ b/nep413/src/lib.rs
@@ -49,7 +49,7 @@ impl Nep413Payload {
 
     #[must_use]
     #[inline]
-    pub fn with_nonce(mut self, nonce: [u8; 32]) -> Self {
+    pub const fn with_nonce(mut self, nonce: [u8; 32]) -> Self {
         self.nonce = nonce;
         self
     }

--- a/poa-factory/src/contract.rs
+++ b/poa-factory/src/contract.rs
@@ -61,6 +61,7 @@ pub struct Contract {
 impl Contract {
     #[must_use]
     #[init]
+    #[allow(clippy::use_self)] // Due to a bug in clippy, even though we return Self, it still complains - happens in shared security analysis
     pub fn new(
         super_admins: HashSet<AccountId>,
         admins: HashMap<Role, HashSet<AccountId>>,

--- a/test-utils/src/random.rs
+++ b/test-utils/src/random.rs
@@ -9,23 +9,23 @@ pub struct Seed(pub u64);
 impl Seed {
     #[must_use]
     pub fn from_entropy() -> Self {
-        Seed(randomness::make_true_rng().next_u64())
+        Self(randomness::make_true_rng().next_u64())
     }
 
     #[must_use]
     pub fn from_entropy_and_print(test_name: &str) -> Self {
-        let result = Seed(randomness::make_true_rng().next_u64());
+        let result = Self(randomness::make_true_rng().next_u64());
         result.print_with_decoration(test_name);
         result
     }
 
     #[must_use]
-    pub fn from_u64(v: u64) -> Self {
-        Seed(v)
+    pub const fn from_u64(v: u64) -> Self {
+        Self(v)
     }
 
     #[must_use]
-    pub fn as_u64(&self) -> u64 {
+    pub const fn as_u64(&self) -> u64 {
         self.0
     }
 
@@ -39,13 +39,13 @@ impl FromStr for Seed {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let v = s.parse::<u64>()?;
-        Ok(Seed::from_u64(v))
+        Ok(Self::from_u64(v))
     }
 }
 
 impl From<u64> for Seed {
     fn from(v: u64) -> Self {
-        Seed::from_u64(v)
+        Self::from_u64(v)
     }
 }
 

--- a/tests/src/tests/defuse/env.rs
+++ b/tests/src/tests/defuse/env.rs
@@ -115,7 +115,7 @@ impl Env {
             .unwrap();
     }
 
-    pub async fn near_balance(&mut self, account_id: &AccountId) -> NearToken {
+    pub async fn near_balance(&self, account_id: &AccountId) -> NearToken {
         self.sandbox
             .worker()
             .view_account(account_id)
@@ -124,7 +124,7 @@ impl Env {
             .balance
     }
 
-    pub fn sandbox(&self) -> &Sandbox {
+    pub const fn sandbox(&self) -> &Sandbox {
         &self.sandbox
     }
 
@@ -156,7 +156,7 @@ pub struct EnvBuilder {
 }
 
 impl EnvBuilder {
-    pub fn fee(mut self, fee: Pips) -> Self {
+    pub const fn fee(mut self, fee: Pips) -> Self {
         self.fee = fee;
         self
     }
@@ -171,17 +171,17 @@ impl EnvBuilder {
         self
     }
 
-    pub fn self_as_super_admin(mut self) -> Self {
+    pub const fn self_as_super_admin(mut self) -> Self {
         self.self_as_super_admin = true;
         self
     }
 
-    pub fn deployer_as_super_admin(mut self) -> Self {
+    pub const fn deployer_as_super_admin(mut self) -> Self {
         self.deployer_as_super_admin = true;
         self
     }
 
-    pub fn disable_ft_storage_deposit(mut self) -> Self {
+    pub const fn disable_ft_storage_deposit(mut self) -> Self {
         self.disable_ft_storage_deposit = true;
         self
     }
@@ -196,7 +196,7 @@ impl EnvBuilder {
         self
     }
 
-    pub fn no_registration(mut self, no_reg_value: bool) -> Self {
+    pub const fn no_registration(mut self, no_reg_value: bool) -> Self {
         self.disable_registration = no_reg_value;
         self
     }
@@ -249,7 +249,7 @@ impl EnvBuilder {
                         wnear_id: wnear.id().clone(),
                         fees: FeesConfig {
                             fee: self.fee,
-                            fee_collector: self.fee_collector.unwrap_or(root.id().clone()),
+                            fee_collector: self.fee_collector.unwrap_or_else(|| root.id().clone()),
                         },
                         roles: self.roles,
                     },

--- a/tests/src/tests/defuse/intents/mod.rs
+++ b/tests/src/tests/defuse/intents/mod.rs
@@ -163,7 +163,7 @@ async fn simulate_is_view_method(#[values(false, true)] no_registration: bool) {
             DefuseIntents {
                 intents: [Transfer {
                     receiver_id: env.user2.id().clone(),
-                    tokens: Amounts::new([(ft1.clone(), 1000)].into_iter().collect()),
+                    tokens: Amounts::new(std::iter::once((ft1.clone(), 1000)).collect()),
                     memo: None,
                 }
                 .into()]

--- a/tests/src/tests/defuse/intents/token_diff.rs
+++ b/tests/src/tests/defuse/intents/token_diff.rs
@@ -42,7 +42,7 @@ async fn swap_p2p(
         [
             AccountFtDiff {
                 account: &env.user1,
-                init_balances: [(&env.ft1, 100)].into_iter().collect(),
+                init_balances: std::iter::once((&env.ft1, 100)).collect(),
                 diff: [TokenDeltas::default()
                     .with_apply_deltas([
                         (ft1_token_id.clone(), -100),
@@ -53,16 +53,15 @@ async fn swap_p2p(
                     ])
                     .unwrap()]
                 .into(),
-                result_balances: [(
+                result_balances: std::iter::once((
                     &env.ft2,
                     TokenDiff::closure_delta(&ft2_token_id, -200, fee).unwrap(),
-                )]
-                .into_iter()
+                ))
                 .collect(),
             },
             AccountFtDiff {
                 account: &env.user2,
-                init_balances: [(&env.ft2, 200)].into_iter().collect(),
+                init_balances: std::iter::once((&env.ft2, 200)).collect(),
                 diff: [TokenDeltas::default()
                     .with_apply_deltas([
                         (
@@ -73,11 +72,10 @@ async fn swap_p2p(
                     ])
                     .unwrap()]
                 .into(),
-                result_balances: [(
+                result_balances: std::iter::once((
                     &env.ft1,
                     TokenDiff::closure_delta(&ft1_token_id, -100, fee).unwrap(),
-                )]
-                .into_iter()
+                ))
                 .collect(),
             },
         ]
@@ -107,16 +105,16 @@ async fn swap_many(
         [
             AccountFtDiff {
                 account: &env.user1,
-                init_balances: [(&env.ft1, 100)].into_iter().collect(),
+                init_balances: std::iter::once((&env.ft1, 100)).collect(),
                 diff: [TokenDeltas::default()
                     .with_apply_deltas([(ft1_token_id.clone(), -100), (ft2_token_id.clone(), 200)])
                     .unwrap()]
                 .into(),
-                result_balances: [(&env.ft2, 200)].into_iter().collect(),
+                result_balances: std::iter::once((&env.ft2, 200)).collect(),
             },
             AccountFtDiff {
                 account: &env.user2,
-                init_balances: [(&env.ft2, 1000)].into_iter().collect(),
+                init_balances: std::iter::once((&env.ft2, 1000)).collect(),
                 diff: [
                     TokenDeltas::default()
                         .with_apply_deltas([
@@ -164,12 +162,12 @@ async fn swap_many(
             },
             AccountFtDiff {
                 account: &env.user3,
-                init_balances: [(&env.ft3, 500)].into_iter().collect(),
+                init_balances: std::iter::once((&env.ft3, 500)).collect(),
                 diff: [TokenDeltas::default()
                     .with_apply_deltas([(ft2_token_id.clone(), 300), (ft3_token_id.clone(), -500)])
                     .unwrap()]
                 .into(),
-                result_balances: [(&env.ft2, 300)].into_iter().collect(),
+                result_balances: std::iter::once((&env.ft2, 300)).collect(),
             },
         ]
         .into(),
@@ -318,7 +316,9 @@ async fn invariant_violated(#[values(false, true)] no_registration: bool) {
             .invariant_violated
             .unwrap()
             .into_unmatched_deltas(),
-        Some(TokenDeltas::new([(ft2.clone(), 1)].into_iter().collect()))
+        Some(TokenDeltas::new(
+            std::iter::once((ft2.clone(), 1)).collect()
+        ))
     );
 
     env.defuse.execute_intents(signed).await.unwrap_err();

--- a/tests/src/tests/defuse/mod.rs
+++ b/tests/src/tests/defuse/mod.rs
@@ -46,7 +46,7 @@ impl DefuseExt for near_workspaces::Account {
 }
 
 impl DefuseExt for Contract {
-    async fn deploy_defuse(&self, id: &str, config: DefuseConfig) -> anyhow::Result<Contract> {
+    async fn deploy_defuse(&self, id: &str, config: DefuseConfig) -> anyhow::Result<Self> {
         self.as_account().deploy_defuse(id, config).await
     }
 }

--- a/tests/src/tests/poa/factory.rs
+++ b/tests/src/tests/poa/factory.rs
@@ -179,7 +179,7 @@ impl PoAFactoryExt for near_workspaces::Contract {
         super_admins: impl IntoIterator<Item = AccountId>,
         admins: impl IntoIterator<Item = (Role, impl IntoIterator<Item = AccountId>)>,
         grantees: impl IntoIterator<Item = (Role, impl IntoIterator<Item = AccountId>)>,
-    ) -> anyhow::Result<Contract> {
+    ) -> anyhow::Result<Self> {
         self.as_account()
             .deploy_poa_factory(name, super_admins, admins, grantees)
             .await

--- a/tests/src/utils/nft.rs
+++ b/tests/src/utils/nft.rs
@@ -168,7 +168,7 @@ impl NftExt for Contract {
         &self,
         token_name: &str,
         metadata: NFTContractMetadata,
-    ) -> anyhow::Result<Contract> {
+    ) -> anyhow::Result<Self> {
         self.as_account()
             .deploy_vanilla_nft_issuer(token_name, metadata)
             .await

--- a/tests/src/utils/wnear.rs
+++ b/tests/src/utils/wnear.rs
@@ -51,7 +51,7 @@ impl WNearExt for Account {
 }
 
 impl WNearExt for Contract {
-    async fn deploy_wrap_near(&self, token: &str) -> anyhow::Result<Contract> {
+    async fn deploy_wrap_near(&self, token: &str) -> anyhow::Result<Self> {
         self.as_account().deploy_wrap_near(token).await
     }
 

--- a/webauthn/src/lib.rs
+++ b/webauthn/src/lib.rs
@@ -73,7 +73,7 @@ impl PayloadSignature {
     const AUTH_DATA_FLAGS_BS: u8 = 1 << 4;
 
     /// <https://w3c.github.io/webauthn/#sctn-verifying-assertion>
-    fn verify_flags(flags: u8, require_user_verification: bool) -> bool {
+    const fn verify_flags(flags: u8, require_user_verification: bool) -> bool {
         // 16. Verify that the UP bit of the flags in authData is set.
         if flags & Self::AUTH_DATA_FLAGS_UP != Self::AUTH_DATA_FLAGS_UP {
             return false;
@@ -168,13 +168,13 @@ impl Signature {
         match self {
             // [COSE EdDSA (-8) algorithm](https://www.iana.org/assignments/cose/cose.xhtml#algorithms):
             // ed25519 curve
-            Signature::Ed25519 {
+            Self::Ed25519 {
                 public_key,
                 signature,
             } => Ed25519::verify(signature, message, public_key).map(PublicKey::Ed25519),
             // [COSE ES256 (-7) algorithm](https://www.iana.org/assignments/cose/cose.xhtml#algorithms):
             // P256 (a.k.a secp256r1) over SHA-256
-            Signature::P256 {
+            Self::P256 {
                 public_key,
                 signature,
             } => {


### PR DESCRIPTION
Over the last few days, cron scheduled CI has been failing. Having cron jobs that don't run on push makes it hard to find issues when doing changes in PRs. 

In this PR, I'll fix all these issues that appeared and add CI for security checks on push.