### PR TITLE
fix: pass remaining gas for *_transfer_call(), do not pass to other XCC

### DIFF
--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -19,8 +19,8 @@ pub enum DefuseError {
     #[error("deadline has expired")]
     DeadlineExpired,
 
-    #[error("insufficient gas")]
-    InsufficientGas,
+    #[error("gas overflow")]
+    GasOverflow,
 
     #[error("invalid intent")]
     InvalidIntent,

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -19,6 +19,9 @@ pub enum DefuseError {
     #[error("deadline has expired")]
     DeadlineExpired,
 
+    #[error("insufficient gas")]
+    InsufficientGas,
+
     #[error("invalid intent")]
     InvalidIntent,
 

--- a/core/src/intents/tokens.rs
+++ b/core/src/intents/tokens.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, collections::BTreeMap};
 
 use near_contract_standards::non_fungible_token;
-use near_sdk::{AccountId, AccountIdRef, CryptoHash, NearToken, json_types::U128, near};
+use near_sdk::{AccountId, AccountIdRef, CryptoHash, Gas, NearToken, json_types::U128, near};
 use serde_with::{DisplayFromStr, serde_as};
 
 use crate::{
@@ -91,7 +91,15 @@ pub struct FtWithdraw {
     /// NOTE: the `wNEAR` will not be refunded in case of fail
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub storage_deposit: Option<NearToken>,
-    // TODO: min_gas?
+
+    /// Optional minimum required Near gas for created Promise to succeed. Defaults are:
+    /// * `ft_transfer`: 15TGas
+    /// * `ft_transfer_call`: 50TGas
+    ///
+    /// Remaining gas will be distributed evenly across all Function Call
+    /// Promises created during execution of current receipt.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_gas: Option<Gas>,
 }
 
 impl ExecutableIntent for FtWithdraw {
@@ -141,6 +149,15 @@ pub struct NftWithdraw {
     /// NOTE: the `wNEAR` will not be refunded in case of fail
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub storage_deposit: Option<NearToken>,
+
+    /// Optional minimum required Near gas for created Promise to succeed. Defaults are:
+    /// * `nft_transfer`: 15TGas
+    /// * `nft_transfer_call`: 50TGas
+    ///
+    /// Remaining gas will be distributed evenly across all Function Call
+    /// Promises created during execution of current receipt.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_gas: Option<Gas>,
 }
 
 impl ExecutableIntent for NftWithdraw {
@@ -194,6 +211,15 @@ pub struct MtWithdraw {
     /// NOTE: the `wNEAR` will not be refunded in case of fail
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub storage_deposit: Option<NearToken>,
+
+    /// Optional minimum required Near gas for created Promise to succeed. Defaults are:
+    /// * `mt_batch_transfer`: 20TGas
+    /// * `mt_batch_transfer_call`: 50TGas
+    ///
+    /// Remaining gas will be distributed evenly across all Function Call
+    /// Promises created during execution of current receipt.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_gas: Option<Gas>,
 }
 impl ExecutableIntent for MtWithdraw {
     #[inline]

--- a/core/src/intents/tokens.rs
+++ b/core/src/intents/tokens.rs
@@ -91,6 +91,7 @@ pub struct FtWithdraw {
     /// NOTE: the `wNEAR` will not be refunded in case of fail
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub storage_deposit: Option<NearToken>,
+    // TODO: min_gas?
 }
 
 impl ExecutableIntent for FtWithdraw {

--- a/defuse/src/contract/intents/state.rs
+++ b/defuse/src/contract/intents/state.rs
@@ -167,11 +167,15 @@ impl State for Contract {
         let _ = ext_wnear::ext(self.wnear_id.clone())
             .with_attached_deposit(NearToken::from_yoctonear(1))
             .with_static_gas(NEAR_WITHDRAW_GAS)
+            // do not distribute remaining gas here
+            .with_unused_gas_weight(0)
             .near_withdraw(U128(withdraw.amount.as_yoctonear()))
             .then(
                 // do_native_withdraw only after unwrapping NEAR
                 Self::ext(CURRENT_ACCOUNT_ID.clone())
                     .with_static_gas(Self::DO_NATIVE_WITHDRAW_GAS)
+                    // do not distribute remaining gas here
+                    .with_unused_gas_weight(0)
                     .do_native_withdraw(withdraw),
             );
 
@@ -196,11 +200,15 @@ impl State for Contract {
         let _ = ext_wnear::ext(self.wnear_id.clone())
             .with_attached_deposit(NearToken::from_yoctonear(1))
             .with_static_gas(NEAR_WITHDRAW_GAS)
+            // do not distribute remaining gas here
+            .with_unused_gas_weight(0)
             .near_withdraw(U128(storage_deposit.amount.as_yoctonear()))
             .then(
                 // do_storage_deposit only after unwrapping NEAR
                 Self::ext(CURRENT_ACCOUNT_ID.clone())
                     .with_static_gas(Self::DO_STORAGE_DEPOSIT_GAS)
+                    // do not distribute remaining gas here
+                    .with_unused_gas_weight(0)
                     .do_storage_deposit(storage_deposit),
             );
 

--- a/defuse/src/contract/tokens/nep141/storage_deposit.rs
+++ b/defuse/src/contract/tokens/nep141/storage_deposit.rs
@@ -6,7 +6,8 @@ use crate::contract::{Contract, ContractExt, tokens::STORAGE_DEPOSIT_GAS};
 
 #[near]
 impl Contract {
-    pub(crate) const DO_STORAGE_DEPOSIT_GAS: Gas = Gas::from_tgas(5);
+    pub(crate) const DO_STORAGE_DEPOSIT_GAS: Gas =
+        Gas::from_tgas(3).saturating_add(STORAGE_DEPOSIT_GAS);
 
     #[private]
     pub fn do_storage_deposit(&mut self, storage_deposit: StorageDeposit) -> Promise {
@@ -18,6 +19,8 @@ impl Contract {
         ext_storage_management::ext(storage_deposit.contract_id)
             .with_attached_deposit(storage_deposit.amount)
             .with_static_gas(STORAGE_DEPOSIT_GAS)
+            // do not distribute remaining gas here
+            .with_unused_gas_weight(0)
             .storage_deposit(Some(storage_deposit.account_id), None)
     }
 }

--- a/defuse/src/contract/tokens/nep141/withdraw.rs
+++ b/defuse/src/contract/tokens/nep141/withdraw.rs
@@ -87,7 +87,7 @@ impl Contract {
                         .with_static_gas(
                             Self::DO_FT_WITHDRAW_GAS
                                 .checked_add(withdraw.min_gas())
-                                .ok_or(DefuseError::InsufficientGas)
+                                .ok_or(DefuseError::GasOverflow)
                                 .unwrap_or_panic(),
                         )
                         .do_ft_withdraw(withdraw.clone()),

--- a/defuse/src/contract/tokens/nep141/withdraw.rs
+++ b/defuse/src/contract/tokens/nep141/withdraw.rs
@@ -118,7 +118,6 @@ impl Contract {
     #[private]
     pub fn do_ft_withdraw(withdraw: FtWithdraw) -> Promise {
         let min_gas = withdraw.min_gas();
-
         let p = if let Some(storage_deposit) = withdraw.storage_deposit {
             require!(
                 matches!(env::promise_result(0), PromiseResult::Successful(data) if data.is_empty()),

--- a/defuse/src/contract/tokens/nep141/withdraw.rs
+++ b/defuse/src/contract/tokens/nep141/withdraw.rs
@@ -9,7 +9,8 @@ use defuse_wnear::{NEAR_WITHDRAW_GAS, ext_wnear};
 use near_contract_standards::storage_management::ext_storage_management;
 use near_plugins::{AccessControllable, Pausable, access_control_any, pause};
 use near_sdk::{
-    AccountId, Gas, NearToken, Promise, PromiseOrValue, PromiseResult, assert_one_yocto, env,
+    AccountId, Gas, GasWeight, NearToken, Promise, PromiseOrValue, PromiseResult, assert_one_yocto,
+    env,
     json_types::U128,
     near, require,
     serde_json::{self, json},
@@ -77,10 +78,13 @@ impl Contract {
             ext_wnear::ext(self.wnear_id.clone())
                 .with_attached_deposit(NearToken::from_yoctonear(1))
                 .with_static_gas(NEAR_WITHDRAW_GAS)
+                // do not distribute remaining gas here
+                .with_unused_gas_weight(0)
                 .near_withdraw(U128(storage_deposit.as_yoctonear()))
                 .then(
                     // schedule storage_deposit() only after near_withdraw() returns
                     Self::ext(CURRENT_ACCOUNT_ID.clone())
+                        // TODO
                         .with_static_gas(Self::DO_FT_WITHDRAW_GAS.saturating_add(if is_call {
                             FT_TRANSFER_CALL_GAS
                         } else {
@@ -94,6 +98,8 @@ impl Contract {
         .then(
             Self::ext(CURRENT_ACCOUNT_ID.clone())
                 .with_static_gas(Self::FT_RESOLVE_WITHDRAW_GAS)
+                // do not distribute remaining gas here
+                .with_unused_gas_weight(0)
                 .ft_resolve_withdraw(withdraw.token, owner_id, withdraw.amount, is_call),
         )
         .into())
@@ -120,6 +126,8 @@ impl Contract {
             ext_storage_management::ext(withdraw.token)
                 .with_attached_deposit(storage_deposit)
                 .with_static_gas(STORAGE_DEPOSIT_GAS)
+                // do not distribute remaining gas here
+                .with_unused_gas_weight(0)
                 .storage_deposit(Some(withdraw.receiver_id.clone()), None)
         } else {
             Promise::new(withdraw.token)
@@ -255,7 +263,7 @@ impl FtExt for Promise {
         memo: Option<&str>,
         msg: &str,
     ) -> Self {
-        self.function_call(
+        self.function_call_weight(
             "ft_transfer_call".to_string(),
             serde_json::to_vec(&json!({
                 "receiver_id": receiver_id,
@@ -266,6 +274,7 @@ impl FtExt for Promise {
             .unwrap_or_panic_display(),
             NearToken::from_yoctonear(1),
             FT_TRANSFER_CALL_GAS,
+            GasWeight::default(),
         )
     }
 }

--- a/defuse/src/contract/tokens/nep171/withdraw.rs
+++ b/defuse/src/contract/tokens/nep171/withdraw.rs
@@ -89,7 +89,7 @@ impl Contract {
                         .with_static_gas(
                             Self::DO_NFT_WITHDRAW_GAS
                                 .checked_add(withdraw.min_gas())
-                                .ok_or(DefuseError::InsufficientGas)
+                                .ok_or(DefuseError::GasOverflow)
                                 .unwrap_or_panic(),
                         )
                         .do_nft_withdraw(withdraw.clone()),

--- a/defuse/src/contract/tokens/nep245/core.rs
+++ b/defuse/src/contract/tokens/nep245/core.rs
@@ -235,7 +235,7 @@ impl Contract {
             )
             .then(
                 Self::ext(CURRENT_ACCOUNT_ID.clone())
-                    // TODO: multiply by number of tokens
+                    // TODO: gas_base + gas_per_token * token_ids.len()
                     .with_static_gas(MT_RESOLVE_TRANSFER_GAS)
                     // do not distribute remaining gas here
                     .with_unused_gas_weight(0)

--- a/defuse/src/contract/tokens/nep245/core.rs
+++ b/defuse/src/contract/tokens/nep245/core.rs
@@ -235,7 +235,10 @@ impl Contract {
             )
             .then(
                 Self::ext(CURRENT_ACCOUNT_ID.clone())
+                    // TODO: multiply by number of tokens
                     .with_static_gas(MT_RESOLVE_TRANSFER_GAS)
+                    // do not distribute remaining gas here
+                    .with_unused_gas_weight(0)
                     .mt_resolve_transfer(previous_owner_ids, receiver_id, token_ids, amounts, None),
             )
             .into())

--- a/defuse/src/contract/tokens/nep245/withdraw.rs
+++ b/defuse/src/contract/tokens/nep245/withdraw.rs
@@ -94,7 +94,7 @@ impl Contract {
                         .with_static_gas(
                             Self::DO_MT_WITHDRAW_GAS
                                 .checked_add(withdraw.min_gas())
-                                .ok_or(DefuseError::InsufficientGas)
+                                .ok_or(DefuseError::GasOverflow)
                                 .unwrap_or_panic(),
                         )
                         .do_mt_withdraw(withdraw.clone()),

--- a/defuse/src/contract/tokens/nep245/withdraw.rs
+++ b/defuse/src/contract/tokens/nep245/withdraw.rs
@@ -12,7 +12,8 @@ use defuse_wnear::{NEAR_WITHDRAW_GAS, ext_wnear};
 use near_contract_standards::storage_management::ext_storage_management;
 use near_plugins::{AccessControllable, Pausable, access_control_any, pause};
 use near_sdk::{
-    AccountId, Gas, NearToken, Promise, PromiseOrValue, PromiseResult, assert_one_yocto, env,
+    AccountId, Gas, GasWeight, NearToken, Promise, PromiseOrValue, PromiseResult, assert_one_yocto,
+    env,
     json_types::U128,
     near, require,
     serde_json::{self, json},
@@ -86,10 +87,13 @@ impl Contract {
             ext_wnear::ext(self.wnear_id.clone())
                 .with_attached_deposit(NearToken::from_yoctonear(1))
                 .with_static_gas(NEAR_WITHDRAW_GAS)
+                // do not distribute remaining gas here
+                .with_unused_gas_weight(0)
                 .near_withdraw(U128(storage_deposit.as_yoctonear()))
                 .then(
                     // schedule storage_deposit() only after near_withdraw() returns
                     Self::ext(CURRENT_ACCOUNT_ID.clone())
+                        // TODO
                         .with_static_gas(Self::DO_MT_WITHDRAW_GAS.saturating_add(if is_call {
                             MT_BATCH_TRANSFER_CALL_GAS
                         } else {
@@ -103,6 +107,8 @@ impl Contract {
         .then(
             Self::ext(CURRENT_ACCOUNT_ID.clone())
                 .with_static_gas(Self::MT_RESOLVE_WITHDRAW_GAS)
+                // do not distribute remaining gas here
+                .with_unused_gas_weight(0)
                 .mt_resolve_withdraw(
                     withdraw.token,
                     owner_id,
@@ -135,6 +141,8 @@ impl Contract {
             ext_storage_management::ext(withdraw.token)
                 .with_attached_deposit(storage_deposit)
                 .with_static_gas(STORAGE_DEPOSIT_GAS)
+                // do not distribute remaining gas here
+                .with_unused_gas_weight(0)
                 .storage_deposit(Some(withdraw.receiver_id.clone()), None)
         } else {
             Promise::new(withdraw.token)
@@ -305,7 +313,7 @@ impl MtExt for Promise {
         memo: Option<&str>,
         msg: &str,
     ) -> Self {
-        self.function_call(
+        self.function_call_weight(
             "mt_batch_transfer_call".to_string(),
             serde_json::to_vec(&json!({
                 "receiver_id": receiver_id,
@@ -317,6 +325,7 @@ impl MtExt for Promise {
             .unwrap_or_panic_display(),
             NearToken::from_yoctonear(1),
             MT_BATCH_TRANSFER_CALL_GAS,
+            GasWeight::default(),
         )
     }
 }

--- a/test-utils/src/asserts.rs
+++ b/test-utils/src/asserts.rs
@@ -9,7 +9,7 @@ thread_local! {
 }
 
 pub trait ResultAssertsExt {
-    fn assert_err_contains(&self, to_contain: impl AsRef<str>);
+    fn assert_err_contains(&self, to_contain: impl Display);
 }
 
 impl<T, E> ResultAssertsExt for Result<T, E>
@@ -17,8 +17,8 @@ where
     E: Display,
 {
     #[track_caller]
-    fn assert_err_contains(&self, to_contain: impl AsRef<str>) {
-        let to_contain = to_contain.as_ref();
+    fn assert_err_contains(&self, to_contain: impl Display) {
+        let to_contain = to_contain.to_string();
         match self {
             Ok(_) => panic!("Result::unwrap_err() on Result::Ok()"),
             Err(e) => {
@@ -27,7 +27,7 @@ where
                 if check_string {
                     let error_string = e.to_string();
                     assert!(
-                        e.to_string().contains(to_contain),
+                        e.to_string().contains(&to_contain),
                         "Result::unwrap_err() successful, but the error string does not contain the expected string.\nError string: `{error_string}`\nshould have contained: `{to_contain}`"
                     );
                 } else {

--- a/test-utils/src/asserts.rs
+++ b/test-utils/src/asserts.rs
@@ -9,7 +9,7 @@ thread_local! {
 }
 
 pub trait ResultAssertsExt {
-    fn assert_err_contains(&self, to_contain: impl Display);
+    fn assert_err_contains(&self, to_contain: impl AsRef<str>);
 }
 
 impl<T, E> ResultAssertsExt for Result<T, E>
@@ -17,8 +17,8 @@ where
     E: Display,
 {
     #[track_caller]
-    fn assert_err_contains(&self, to_contain: impl Display) {
-        let to_contain = to_contain.to_string();
+    fn assert_err_contains(&self, to_contain: impl AsRef<str>) {
+        let to_contain = to_contain.as_ref();
         match self {
             Ok(_) => panic!("Result::unwrap_err() on Result::Ok()"),
             Err(e) => {
@@ -27,7 +27,7 @@ where
                 if check_string {
                     let error_string = e.to_string();
                     assert!(
-                        e.to_string().contains(&to_contain),
+                        e.to_string().contains(to_contain),
                         "Result::unwrap_err() successful, but the error string does not contain the expected string.\nError string: `{error_string}`\nshould have contained: `{to_contain}`"
                     );
                 } else {

--- a/tests/src/tests/defuse/intents/ft_withdraw.rs
+++ b/tests/src/tests/defuse/intents/ft_withdraw.rs
@@ -184,7 +184,7 @@ async fn ft_withdraw_intent(random_seed: Seed, #[values(false, true)] no_registr
         )],
     )
     .await
-    .assert_err_contains(DefuseError::InsufficientGas);
+    .assert_err_contains("Exceeded the prepaid gas.");
 
     env.defuse_execute_intents(
         env.defuse.id(),

--- a/tests/src/tests/defuse/intents/ft_withdraw.rs
+++ b/tests/src/tests/defuse/intents/ft_withdraw.rs
@@ -9,7 +9,7 @@ use arbitrary::{Arbitrary, Unstructured};
 use defuse::{
     contract::config::{DefuseConfig, RolesConfig},
     core::{
-        Deadline,
+        Deadline, DefuseError,
         fees::{FeesConfig, Pips},
         intents::{DefuseIntents, tokens::FtWithdraw},
         tokens::TokenId,
@@ -19,8 +19,8 @@ use near_sdk::{AccountId, Gas, NearToken};
 use randomness::Rng;
 use rstest::rstest;
 use std::time::Duration;
-use test_utils::random::make_seedable_rng;
 use test_utils::random::{Seed, random_seed};
+use test_utils::{asserts::ResultAssertsExt, random::make_seedable_rng};
 
 #[tokio::test]
 #[rstest]
@@ -184,7 +184,7 @@ async fn ft_withdraw_intent(random_seed: Seed, #[values(false, true)] no_registr
         )],
     )
     .await
-    .unwrap_err();
+    .assert_err_contains(DefuseError::InsufficientGas);
 
     env.defuse_execute_intents(
         env.defuse.id(),

--- a/tests/src/tests/defuse/intents/ft_withdraw.rs
+++ b/tests/src/tests/defuse/intents/ft_withdraw.rs
@@ -9,7 +9,7 @@ use arbitrary::{Arbitrary, Unstructured};
 use defuse::{
     contract::config::{DefuseConfig, RolesConfig},
     core::{
-        Deadline, DefuseError,
+        Deadline,
         fees::{FeesConfig, Pips},
         intents::{DefuseIntents, tokens::FtWithdraw},
         tokens::TokenId,

--- a/tests/src/tests/defuse/intents/mod.rs
+++ b/tests/src/tests/defuse/intents/mod.rs
@@ -274,6 +274,7 @@ async fn ton_connect_sign_intent_example(random_seed: Seed) {
             memo: None,
             msg: None,
             storage_deposit: None,
+            min_gas: None,
         }
         .into()]
         .into(),

--- a/tests/src/tests/defuse/tokens/nep141.rs
+++ b/tests/src/tests/defuse/tokens/nep141.rs
@@ -153,6 +153,7 @@ async fn deposit_withdraw_intent(random_seed: Seed, #[values(false, true)] no_re
                                     memo: None,
                                     msg: None,
                                     storage_deposit: None,
+                                    min_gas: None,
                                 }
                                 .into(),
                             ]
@@ -252,6 +253,7 @@ async fn deposit_withdraw_intent_refund(
                                 memo: None,
                                 msg: None,
                                 storage_deposit: None,
+                                min_gas: None,
                             }
                             .into(),]
                             .into(),

--- a/tests/src/tests/defuse/tokens/nep171.rs
+++ b/tests/src/tests/defuse/tokens/nep171.rs
@@ -262,6 +262,7 @@ async fn transfer_nft_to_verifier(random_seed: Seed) {
                         memo: None,
                         msg: None,
                         storage_deposit: None,
+                        min_gas: None,
                     }
                     .into()]
                     .into(),


### PR DESCRIPTION
This PR solves [insufficient gas](https://nearblocks.io/txns/7a1N7uZH5EmTTYsqxwmKXe7aFw5q3J23NpTKoFwe6fiD?tab=execution) issue during withdrawals.
Namely, it introduces `min_gas` field for `ft/nft/mt_withdraw` intents and makes `intents.near` contract distribute remaining gas across all `ft/nft/mt_transfer[_call]()` Promises.