### PR TITLE
Add SEP-53 signatures support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3311,7 +3311,6 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 name = "sep53"
 version = "0.1.0"
 dependencies = [
- "base64 0.22.1",
  "defuse-crypto",
  "defuse-near-utils",
  "defuse-serde-utils",
@@ -3320,7 +3319,6 @@ dependencies = [
  "near-crypto",
  "near-sdk",
  "serde_with",
- "sha2",
  "stellar-strkey",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,6 +710,7 @@ dependencies = [
  "defuse-nep245",
  "defuse-nep413",
  "defuse-num-utils",
+ "defuse-sep53",
  "defuse-serde-utils",
  "defuse-test-utils",
  "defuse-ton-connect",
@@ -837,6 +838,21 @@ name = "defuse-randomness"
 version = "0.1.0"
 dependencies = [
  "rand 0.9.1",
+]
+
+[[package]]
+name = "defuse-sep53"
+version = "0.1.0"
+dependencies = [
+ "defuse-crypto",
+ "defuse-near-utils",
+ "defuse-serde-utils",
+ "ed25519-dalek",
+ "impl-tools",
+ "near-crypto",
+ "near-sdk",
+ "serde_with",
+ "stellar-strkey",
 ]
 
 [[package]]
@@ -1077,7 +1093,6 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
  "signature",
 ]
 
@@ -1090,10 +1105,8 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand_core 0.6.4",
- "serde",
  "sha2",
  "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -2736,16 +2749,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3308,21 +3311,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
-name = "sep53"
-version = "0.1.0"
-dependencies = [
- "defuse-crypto",
- "defuse-near-utils",
- "defuse-serde-utils",
- "ed25519-dalek",
- "impl-tools",
- "near-crypto",
- "near-sdk",
- "serde_with",
- "stellar-strkey",
-]
-
-[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3536,16 +3524,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "crate-git-revision"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c521bf1f43d31ed2f73441775ed31935d77901cb3451e44b38a1c1612fcbaf98"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
 name = "crc"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,6 +630,12 @@ dependencies = [
  "quote",
  "syn 2.0.101",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "defuse"
@@ -1060,6 +1077,7 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
+ "pkcs8",
  "signature",
 ]
 
@@ -1072,8 +1090,10 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand_core 0.6.4",
+ "serde",
  "sha2",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2716,6 +2736,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3278,6 +3308,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
+name = "sep53"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "defuse-crypto",
+ "defuse-near-utils",
+ "defuse-serde-utils",
+ "ed25519-dalek",
+ "impl-tools",
+ "near-crypto",
+ "near-sdk",
+ "serde_with",
+ "sha2",
+ "stellar-strkey",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3493,6 +3540,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3503,6 +3560,16 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stellar-strkey"
+version = "0.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee1832fb50c651ad10f734aaf5d31ca5acdfb197a6ecda64d93fcdb8885af913"
+dependencies = [
+ "crate-git-revision",
+ "data-encoding",
+]
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,10 +847,12 @@ dependencies = [
  "defuse-crypto",
  "defuse-near-utils",
  "defuse-serde-utils",
+ "defuse-test-utils",
  "ed25519-dalek",
  "impl-tools",
  "near-crypto",
  "near-sdk",
+ "rstest",
  "serde_with",
  "stellar-strkey",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
     "tests",
     "test-utils",
     "ton-connect",
-    "wnear",
+    "wnear", "sep53",
 ]
 default-members = ["defuse"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ rstest = "0.25"
 schemars = "0.8"
 serde_json = "1"
 serde_with = "3.9"
+stellar-strkey = "0.0"
 strum = { version = "0.27", features = ["derive"] }
 thiserror = "2"
 tlb-ton = { version = "0.5", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,12 @@ members = [
     "poa-factory",
     "poa-token",
     "randomness",
+    "sep53",
     "serde-utils",
     "tests",
     "test-utils",
     "ton-connect",
-    "wnear", "sep53",
+    "wnear",
 ]
 default-members = ["defuse"]
 
@@ -53,6 +54,7 @@ defuse-num-utils.path = "num-utils"
 defuse-webauthn.path = "webauthn"
 defuse-poa-factory.path = "poa-factory"
 defuse-poa-token.path = "poa-token"
+defuse-sep53.path = "sep53"
 defuse-serde-utils.path = "serde-utils"
 defuse-ton-connect.path = "ton-connect"
 defuse-wnear.path = "wnear"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -37,6 +37,7 @@ abi = [
     "defuse-crypto/abi",
     "defuse-erc191/abi",
     "defuse-nep413/abi",
+    "defuse-sep53/abi",
     "defuse-serde-utils/abi",
     "defuse-ton-connect/abi",
     "defuse-webauthn/abi",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,6 +16,7 @@ defuse-near-utils = { workspace = true, features = ["time"] }
 defuse-num-utils.workspace = true
 defuse-serde-utils.workspace = true
 defuse-ton-connect.workspace = true
+defuse-sep53.workspace = true
 defuse-webauthn.workspace = true
 
 arbitrary = { workspace = true, optional = true }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -15,4 +15,5 @@ pub use self::{deadline::*, error::*, nonce::*};
 pub use defuse_crypto as crypto;
 pub use defuse_erc191 as erc191;
 pub use defuse_nep413 as nep413;
+pub use defuse_sep53 as sep53;
 pub use defuse_ton_connect as ton_connect;

--- a/core/src/payload/mod.rs
+++ b/core/src/payload/mod.rs
@@ -2,6 +2,7 @@ pub mod erc191;
 pub mod multi;
 pub mod nep413;
 pub mod raw;
+pub mod sep53;
 pub mod ton_connect;
 pub mod webauthn;
 

--- a/core/src/payload/multi.rs
+++ b/core/src/payload/multi.rs
@@ -1,6 +1,7 @@
 use defuse_crypto::{Payload, PublicKey, SignedPayload};
 use defuse_erc191::SignedErc191Payload;
 use defuse_nep413::SignedNep413Payload;
+use defuse_sep53::SignedSep53Payload;
 use defuse_ton_connect::SignedTonConnectPayload;
 use derive_more::derive::From;
 use near_sdk::{CryptoHash, near, serde::de::DeserializeOwned, serde_json};
@@ -41,6 +42,10 @@ pub enum MultiPayload {
     /// TonConnect: The standard for data signing in TON blockchain platform.
     /// For more details, refer to [TonConnect documentation](https://docs.tonconsole.com/academy/sign-data).
     TonConnect(SignedTonConnectPayload),
+
+    /// SEP-53: The standard for signing data off-chain for Stellar accounts.
+    /// See [SEP-53](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0053.md)
+    Sep53(SignedSep53Payload),
 }
 
 impl Payload for MultiPayload {
@@ -56,6 +61,7 @@ impl Payload for MultiPayload {
             Self::RawEd25519(payload) => payload.hash(),
             Self::WebAuthn(payload) => payload.hash(),
             Self::TonConnect(payload) => payload.hash(),
+            Self::Sep53(payload) => payload.hash(),
         }
     }
 }
@@ -71,6 +77,7 @@ impl SignedPayload for MultiPayload {
             Self::RawEd25519(payload) => payload.verify().map(PublicKey::Ed25519),
             Self::WebAuthn(payload) => payload.verify(),
             Self::TonConnect(payload) => payload.verify().map(PublicKey::Ed25519),
+            Self::Sep53(payload) => payload.verify().map(PublicKey::Ed25519),
         }
     }
 }
@@ -89,6 +96,7 @@ where
             Self::RawEd25519(payload) => payload.extract_defuse_payload(),
             Self::WebAuthn(payload) => payload.extract_defuse_payload(),
             Self::TonConnect(payload) => payload.extract_defuse_payload(),
+            Self::Sep53(payload) => payload.extract_defuse_payload(),
         }
     }
 }

--- a/core/src/payload/sep53.rs
+++ b/core/src/payload/sep53.rs
@@ -1,10 +1,6 @@
-use defuse_sep53::{Sep53Payload, SignedSep53Payload};
-use near_sdk::{
-    serde::de::{DeserializeOwned, Error},
-    serde_json,
-};
-
 use crate::payload::{DefusePayload, ExtractDefusePayload};
+use defuse_sep53::{Sep53Payload, SignedSep53Payload};
+use near_sdk::{serde::de::DeserializeOwned, serde_json};
 
 impl<T> ExtractDefusePayload<T> for SignedSep53Payload
 where
@@ -25,11 +21,6 @@ where
     type Error = serde_json::Error;
 
     fn extract_defuse_payload(self) -> Result<DefusePayload<T>, Self::Error> {
-        let message_string = String::from_utf8(self.message).map_err(|_| {
-            serde_json::Error::custom("Invalid SEP-53 message. Only UTF-8 strings are supported.")
-        })?;
-        let p: DefusePayload<T> = serde_json::from_str(&message_string)?;
-
-        Ok(p)
+        serde_json::from_str(&self.message)
     }
 }

--- a/core/src/payload/sep53.rs
+++ b/core/src/payload/sep53.rs
@@ -21,6 +21,6 @@ where
     type Error = serde_json::Error;
 
     fn extract_defuse_payload(self) -> Result<DefusePayload<T>, Self::Error> {
-        serde_json::from_str(&self.message)
+        serde_json::from_str(&self.payload)
     }
 }

--- a/core/src/payload/sep53.rs
+++ b/core/src/payload/sep53.rs
@@ -1,0 +1,35 @@
+use defuse_sep53::{Sep53Payload, SignedSep53Payload};
+use near_sdk::{
+    serde::de::{DeserializeOwned, Error},
+    serde_json,
+};
+
+use crate::payload::{DefusePayload, ExtractDefusePayload};
+
+impl<T> ExtractDefusePayload<T> for SignedSep53Payload
+where
+    T: DeserializeOwned,
+{
+    type Error = serde_json::Error;
+
+    #[inline]
+    fn extract_defuse_payload(self) -> Result<DefusePayload<T>, Self::Error> {
+        self.payload.extract_defuse_payload()
+    }
+}
+
+impl<T> ExtractDefusePayload<T> for Sep53Payload
+where
+    T: DeserializeOwned,
+{
+    type Error = serde_json::Error;
+
+    fn extract_defuse_payload(self) -> Result<DefusePayload<T>, Self::Error> {
+        let message_string = String::from_utf8(self.message).map_err(|_| {
+            serde_json::Error::custom("Invalid SEP-53 message. Only UTF-8 strings are supported.")
+        })?;
+        let p: DefusePayload<T> = serde_json::from_str(&message_string)?;
+
+        Ok(p)
+    }
+}

--- a/sep53/Cargo.toml
+++ b/sep53/Cargo.toml
@@ -19,8 +19,6 @@ near-crypto.workspace = true
 # FIXME: move to root Cargo.toml
 stellar-strkey = "0.0"
 ed25519-dalek = "2.0"
-base64 = "0.22"
-sha2 = "0.10"
 
 [features]
 abi = ["defuse-serde-utils/abi", "defuse-crypto/abi"]

--- a/sep53/Cargo.toml
+++ b/sep53/Cargo.toml
@@ -15,10 +15,11 @@ near-sdk = { workspace = true, features = ["unit-testing"] }
 serde_with.workspace = true
 
 [dev-dependencies]
+defuse-test-utils.workspace = true
 ed25519-dalek.workspace = true
 near-crypto.workspace = true
-# FIXME: move to root Cargo.toml
-stellar-strkey = "0.0"
+rstest.workspace = true
+stellar-strkey.workspace = true
 
 [features]
 abi = ["defuse-serde-utils/abi", "defuse-crypto/abi"]

--- a/sep53/Cargo.toml
+++ b/sep53/Cargo.toml
@@ -11,7 +11,7 @@ defuse-near-utils.workspace = true
 defuse-serde-utils.workspace = true
 
 impl-tools.workspace = true
-near-sdk = { workspace = true, features = ["unit-testing"] }
+near-sdk.workspace = true
 serde_with.workspace = true
 
 [dev-dependencies]
@@ -20,6 +20,7 @@ ed25519-dalek.workspace = true
 near-crypto.workspace = true
 rstest.workspace = true
 stellar-strkey.workspace = true
+near-sdk = { workspace = true, features = ["unit-testing"] }
 
 [features]
 abi = ["defuse-serde-utils/abi", "defuse-crypto/abi"]

--- a/sep53/Cargo.toml
+++ b/sep53/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "sep53"
+edition.workspace = true
+repository.workspace = true
+version.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+defuse-crypto = { workspace = true, features = ["serde"] }
+defuse-near-utils.workspace = true
+defuse-serde-utils.workspace = true
+
+impl-tools.workspace = true
+near-sdk = { workspace = true, features = ["unit-testing"] }
+serde_with.workspace = true
+
+[dev-dependencies]
+near-crypto.workspace = true
+# FIXME: move to root Cargo.toml
+stellar-strkey = "0.0"
+ed25519-dalek = "2.0"
+base64 = "0.22"
+sha2 = "0.10"
+
+[features]
+abi = ["defuse-serde-utils/abi", "defuse-crypto/abi"]
+
+[lints]
+workspace = true

--- a/sep53/Cargo.toml
+++ b/sep53/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sep53"
+name = "defuse-sep53"
 edition.workspace = true
 repository.workspace = true
 version.workspace = true
@@ -15,10 +15,10 @@ near-sdk = { workspace = true, features = ["unit-testing"] }
 serde_with.workspace = true
 
 [dev-dependencies]
+ed25519-dalek.workspace = true
 near-crypto.workspace = true
 # FIXME: move to root Cargo.toml
 stellar-strkey = "0.0"
-ed25519-dalek = "2.0"
 
 [features]
 abi = ["defuse-serde-utils/abi", "defuse-crypto/abi"]

--- a/sep53/src/lib.rs
+++ b/sep53/src/lib.rs
@@ -81,15 +81,13 @@ impl SignedPayload for SignedSep53Payload {
 
 #[cfg(test)]
 mod tests {
-
+    use crate::{Sep53Payload, SignedSep53Payload};
     use base64::{Engine, engine::general_purpose::STANDARD};
     use defuse_crypto::{Payload, SignedPayload};
     use ed25519_dalek::Verifier;
     use ed25519_dalek::{SigningKey, ed25519::signature::SignerMut};
     use near_sdk::base64;
     use stellar_strkey::Strkey;
-
-    use crate::{Sep53Payload, SignedSep53Payload};
 
     #[test]
     fn reference_test_vectors() {

--- a/sep53/src/lib.rs
+++ b/sep53/src/lib.rs
@@ -1,0 +1,164 @@
+use defuse_crypto::{CryptoHash, Curve, Ed25519, Payload, SignedPayload, serde::AsCurve};
+use impl_tools::autoimpl;
+use near_sdk::{env, near};
+use serde_with::serde_as;
+
+/// See [SEP-53](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0053.md)
+#[cfg_attr(
+    all(feature = "abi", not(target_arch = "wasm32")),
+    serde_as(schemars = true)
+)]
+#[cfg_attr(
+    not(all(feature = "abi", not(target_arch = "wasm32"))),
+    serde_as(schemars = false)
+)]
+#[near(serializers = [borsh, json])]
+#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
+#[must_use]
+pub struct Sep53Payload {
+    pub message: Vec<u8>,
+}
+
+impl Sep53Payload {
+    #[inline]
+    pub const fn new(message: Vec<u8>) -> Self {
+        Self { message }
+    }
+
+    #[inline]
+    pub fn prehash(&self) -> Vec<u8> {
+        b"Stellar Signed Message:\n"
+            .iter()
+            .copied()
+            .chain(self.message.as_slice().iter().copied())
+            .collect()
+    }
+}
+
+impl Payload for Sep53Payload {
+    #[inline]
+    fn hash(&self) -> CryptoHash {
+        env::sha256_array(&self.prehash())
+    }
+}
+
+#[cfg_attr(
+    all(feature = "abi", not(target_arch = "wasm32")),
+    serde_as(schemars = true)
+)]
+#[cfg_attr(
+    not(all(feature = "abi", not(target_arch = "wasm32"))),
+    serde_as(schemars = false)
+)]
+#[near(serializers = [json])]
+#[autoimpl(Deref using self.payload)]
+#[derive(Debug, Clone)]
+pub struct SignedSep53Payload {
+    pub payload: Sep53Payload,
+
+    #[serde_as(as = "AsCurve<Ed25519>")]
+    pub public_key: <Ed25519 as Curve>::PublicKey,
+    #[serde_as(as = "AsCurve<Ed25519>")]
+    pub signature: <Ed25519 as Curve>::Signature,
+}
+
+impl Payload for SignedSep53Payload {
+    #[inline]
+    fn hash(&self) -> CryptoHash {
+        self.payload.hash()
+    }
+}
+
+impl SignedPayload for SignedSep53Payload {
+    type PublicKey = <Ed25519 as Curve>::PublicKey;
+
+    #[inline]
+    fn verify(&self) -> Option<Self::PublicKey> {
+        Ed25519::verify(&self.signature, &self.hash(), &self.public_key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use base64::{Engine, engine::general_purpose::STANDARD};
+    use defuse_crypto::Payload;
+    use ed25519_dalek::Verifier;
+    use ed25519_dalek::ed25519::signature::digest::Digest;
+    use ed25519_dalek::{SigningKey, ed25519::signature::SignerMut};
+    use near_sdk::base64;
+    use sha2::Sha256;
+    use stellar_strkey::Strkey;
+
+    use crate::Sep53Payload;
+
+    #[test]
+    fn reference_test_vectors() {
+        // 1) Decode the StrKey seed → raw 32 bytes
+        let seed = "SAKICEVQLYWGSOJS4WW7HZJWAHZVEEBS527LHK5V4MLJALYKICQCJXMW";
+        let raw = match Strkey::from_string(seed).unwrap() {
+            Strkey::PrivateKeyEd25519(pk) => pk.0,
+            _ => panic!("expected an Ed25519 seed"),
+        };
+
+        // 2) Build SigningKey + VerifyingKey
+        let mut signing_key = SigningKey::from_bytes(&raw);
+        let verifying_key = signing_key.verifying_key();
+
+        let vectors = [
+            (
+                b"Hello, World!".as_ref(),
+                "fO5dbYhXUhBMhe6kId/cuVq/AfEnHRHEvsP8vXh03M1uLpi5e46yO2Q8rEBzu3feXQewcQE5GArp88u6ePK6BA==",
+            ),
+            (
+                "こんにちは、世界！".as_bytes(),
+                "CDU265Xs8y3OWbB/56H9jPgUss5G9A0qFuTqH2zs2YDgTm+++dIfmAEceFqB7bhfN3am59lCtDXrCtwH2k1GBA==",
+            ),
+            (
+                &STANDARD
+                    .decode("2zZDP1sa1BVBfLP7TeeMk3sUbaxAkUhBhDiNdrksaFo=")
+                    .unwrap(),
+                "VA1+7hefNwv2NKScH6n+Sljj15kLAge+M2wE7fzFOf+L0MMbssA1mwfJZRyyrhBORQRle10X1Dxpx+UOI4EbDQ==",
+            ),
+        ];
+
+        for (msg, expected_b64) in vectors {
+            let mut payload = b"Stellar Signed Message:\n".to_vec();
+            payload.extend_from_slice(msg);
+
+            let hash = Sha256::digest(&payload);
+            let sig = signing_key.sign(hash.as_ref());
+            let actual_b64 = STANDARD.encode(sig.to_bytes());
+
+            assert_eq!(actual_b64, *expected_b64);
+            assert!(verifying_key.verify(hash.as_ref(), &sig).is_ok());
+        }
+
+        for (msg, expected_sig_b64) in vectors {
+            let payload = Sep53Payload::new(msg.to_vec());
+
+            let hash = payload.hash();
+            let key = near_crypto::SecretKey::ED25519(near_crypto::ED25519SecretKey(
+                signing_key
+                    .as_bytes()
+                    .iter()
+                    .chain(verifying_key.as_bytes())
+                    .copied()
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap(),
+            ));
+            let generic_sig = key.sign(hash.as_ref());
+            let sig = match generic_sig {
+                near_crypto::Signature::ED25519(signature) => signature,
+                near_crypto::Signature::SECP256K1(_) => unreachable!(),
+            };
+
+            let actual_sig_b64 = STANDARD.encode(sig.to_bytes());
+
+            assert_eq!(actual_sig_b64, *expected_sig_b64);
+            assert!(generic_sig.verify(hash.as_ref(), &key.public_key()));
+        }
+    }
+}

--- a/sep53/src/lib.rs
+++ b/sep53/src/lib.rs
@@ -4,15 +4,7 @@ use near_sdk::{env, near};
 use serde_with::serde_as;
 
 /// See [SEP-53](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0053.md)
-#[cfg_attr(
-    all(feature = "abi", not(target_arch = "wasm32")),
-    serde_as(schemars = true)
-)]
-#[cfg_attr(
-    not(all(feature = "abi", not(target_arch = "wasm32"))),
-    serde_as(schemars = false)
-)]
-#[near(serializers = [borsh, json])]
+#[near(serializers = [json])]
 #[serde(rename_all = "camelCase")]
 #[derive(Debug, Clone)]
 #[must_use]

--- a/sep53/src/lib.rs
+++ b/sep53/src/lib.rs
@@ -85,17 +85,15 @@ mod tests {
     use base64::{Engine, engine::general_purpose::STANDARD};
     use defuse_crypto::{Payload, SignedPayload};
     use ed25519_dalek::Verifier;
-    use ed25519_dalek::ed25519::signature::digest::Digest;
     use ed25519_dalek::{SigningKey, ed25519::signature::SignerMut};
     use near_sdk::base64;
-    use sha2::Sha256;
     use stellar_strkey::Strkey;
 
     use crate::{Sep53Payload, SignedSep53Payload};
 
     #[test]
     fn reference_test_vectors() {
-        // 1) Decode the StrKey seed → raw 32 bytes
+        // 1) Decode the StrKey seed -> raw 32 bytes
         let seed = "SAKICEVQLYWGSOJS4WW7HZJWAHZVEEBS527LHK5V4MLJALYKICQCJXMW";
         let raw = match Strkey::from_string(seed).unwrap() {
             Strkey::PrivateKeyEd25519(pk) => pk.0,
@@ -128,7 +126,7 @@ mod tests {
             let mut payload = b"Stellar Signed Message:\n".to_vec();
             payload.extend_from_slice(msg);
 
-            let hash = Sha256::digest(&payload);
+            let hash = near_sdk::env::sha256_array(&payload);
             let sig = signing_key.sign(hash.as_ref());
             let actual_b64 = STANDARD.encode(sig.to_bytes());
 

--- a/sep53/src/lib.rs
+++ b/sep53/src/lib.rs
@@ -139,7 +139,7 @@ mod tests {
             let payload = Sep53Payload::new(msg.to_vec());
 
             let hash = payload.hash();
-            let key = near_crypto::SecretKey::ED25519(near_crypto::ED25519SecretKey(
+            let secret_key = near_crypto::SecretKey::ED25519(near_crypto::ED25519SecretKey(
                 signing_key
                     .as_bytes()
                     .iter()
@@ -149,7 +149,7 @@ mod tests {
                     .try_into()
                     .unwrap(),
             ));
-            let generic_sig = key.sign(hash.as_ref());
+            let generic_sig = secret_key.sign(hash.as_ref());
             let sig = match generic_sig {
                 near_crypto::Signature::ED25519(signature) => signature,
                 near_crypto::Signature::SECP256K1(_) => unreachable!(),
@@ -158,7 +158,7 @@ mod tests {
             let actual_sig_b64 = STANDARD.encode(sig.to_bytes());
 
             assert_eq!(actual_sig_b64, *expected_sig_b64);
-            assert!(generic_sig.verify(hash.as_ref(), &key.public_key()));
+            assert!(generic_sig.verify(hash.as_ref(), &secret_key.public_key()));
 
             let signed_payload = SignedSep53Payload {
                 payload,

--- a/sep53/src/lib.rs
+++ b/sep53/src/lib.rs
@@ -19,11 +19,7 @@ impl Sep53Payload {
 
     #[inline]
     pub fn prehash(&self) -> Vec<u8> {
-        [
-            "Stellar Signed Message:\n".as_bytes(),
-            self.message.as_bytes(),
-        ]
-        .concat()
+        [b"Stellar Signed Message:\n", self.message.as_bytes()].concat()
     }
 }
 
@@ -110,7 +106,7 @@ mod tests {
             let mut payload = "Stellar Signed Message:\n".to_string();
             payload += msg;
 
-            let hash = near_sdk::env::sha256_array(&payload.as_bytes());
+            let hash = near_sdk::env::sha256_array(payload.as_bytes());
             let sig = signing_key.sign(hash.as_ref());
             let actual_b64 = STANDARD.encode(sig.to_bytes());
 

--- a/tests/src/tests/defuse/intents/native_withdraw.rs
+++ b/tests/src/tests/defuse/intents/native_withdraw.rs
@@ -81,7 +81,7 @@ async fn native_withdraw_intent(mut rng: impl Rng) {
     env.defuse_execute_intents(
         env.defuse.id(),
         [env.user2.sign_defuse_message(
-            SigningStandard::Nep413,
+            SigningStandard::default(),
             env.defuse.id(),
             rng.random(),
             Deadline::timeout(Duration::from_secs(120)),

--- a/tests/src/tests/defuse/intents/token_diff.rs
+++ b/tests/src/tests/defuse/intents/token_diff.rs
@@ -209,7 +209,7 @@ async fn test_ft_diffs(env: &Env, accounts: Vec<AccountFtDiff<'_>>) {
         .flat_map(move |account| {
             account.diff.iter().cloned().map(move |diff| {
                 account.account.sign_defuse_message(
-                    SigningStandard::Nep413,
+                    SigningStandard::default(),
                     env.defuse.id(),
                     make_true_rng().random(),
                     Deadline::timeout(Duration::from_secs(120)),

--- a/tests/src/tests/defuse/mod.rs
+++ b/tests/src/tests/defuse/mod.rs
@@ -116,16 +116,13 @@ impl DefuseSigner for near_workspaces::Account {
                 .into(),
             SigningStandard::Sep53 => self
                 .sign_sep53(Sep53Payload::new(
-                    serde_json::to_string(
-                        &serde_json::to_string(&DefusePayload {
-                            signer_id: self.id().clone(),
-                            verifying_contract: defuse_contract.clone(),
-                            deadline,
-                            nonce,
-                            message,
-                        })
-                        .unwrap(),
-                    )
+                    serde_json::to_string(&DefusePayload {
+                        signer_id: self.id().clone(),
+                        verifying_contract: defuse_contract.clone(),
+                        deadline,
+                        nonce,
+                        message,
+                    })
                     .unwrap(),
                 ))
                 .into(),

--- a/tests/src/tests/defuse/mod.rs
+++ b/tests/src/tests/defuse/mod.rs
@@ -9,6 +9,7 @@ use self::accounts::AccountManagerExt;
 use crate::utils::{account::AccountExt, crypto::Signer, read_wasm};
 use arbitrary::{Arbitrary, Unstructured};
 use defuse::core::payload::DefusePayload;
+use defuse::core::sep53::Sep53Payload;
 use defuse::core::ton_connect::tlb_ton::MsgAddress;
 use defuse::{
     contract::config::DefuseConfig,
@@ -113,6 +114,21 @@ impl DefuseSigner for near_workspaces::Account {
                     },
                 })
                 .into(),
+            SigningStandard::Sep53 => self
+                .sign_sep53(Sep53Payload::new(
+                    serde_json::to_string(
+                        &serde_json::to_string(&DefusePayload {
+                            signer_id: self.id().clone(),
+                            verifying_contract: defuse_contract.clone(),
+                            deadline,
+                            nonce,
+                            message,
+                        })
+                        .unwrap(),
+                    )
+                    .unwrap(),
+                ))
+                .into(),
         }
     }
 }
@@ -122,4 +138,5 @@ pub enum SigningStandard {
     #[default]
     Nep413,
     TonConnect,
+    Sep53,
 }

--- a/tests/src/utils/crypto.rs
+++ b/tests/src/utils/crypto.rs
@@ -1,6 +1,7 @@
 use defuse::core::{
     crypto::Payload,
     nep413::{Nep413Payload, SignedNep413Payload},
+    sep53::{Sep53Payload, SignedSep53Payload},
     ton_connect::{SignedTonConnectPayload, TonConnectPayload},
 };
 use near_workspaces::Account;
@@ -10,6 +11,7 @@ pub trait Signer {
 
     fn sign_nep413(&self, payload: Nep413Payload) -> SignedNep413Payload;
     fn sign_ton_connect(&self, payload: TonConnectPayload) -> SignedTonConnectPayload;
+    fn sign_sep53(&self, payload: Sep53Payload) -> SignedSep53Payload;
 }
 
 impl Signer for Account {
@@ -39,6 +41,21 @@ impl Signer for Account {
         match (secret_key.sign(&payload.hash()), secret_key.public_key()) {
             (near_crypto::Signature::ED25519(sig), near_crypto::PublicKey::ED25519(pk)) => {
                 SignedTonConnectPayload {
+                    payload,
+                    public_key: pk.0,
+                    signature: sig.to_bytes(),
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn sign_sep53(&self, payload: Sep53Payload) -> SignedSep53Payload {
+        let secret_key = Signer::secret_key(self);
+
+        match (secret_key.sign(&payload.hash()), secret_key.public_key()) {
+            (near_crypto::Signature::ED25519(sig), near_crypto::PublicKey::ED25519(pk)) => {
+                SignedSep53Payload {
                     payload,
                     public_key: pk.0,
                     signature: sig.to_bytes(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the SEP-53 signing standard for Stellar accounts, enabling message signing and verification using Ed25519 cryptography.
  - Introduced new payload types for SEP-53, allowing integration with existing multi-standard payload handling.
  - Extended test suite to cover SEP-53 signing, verification, and interoperability.
  - Enabled signing SEP-53 payloads in test utilities and signing workflows.

- **Bug Fixes**
  - None.

- **Chores**
  - Updated workspace and dependency configurations to include the new SEP-53 module and related dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->