### PR TITLE
docs: explain payload traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ For more information on how to use the Intents ecosystem, please refer to [the d
 
 For technical information about the Verifier smart contract programming primitives (and other smart contracts here), please refer to [the cargo documentation page](https://near.github.io/intents/).
 
+### Payload traits
+
+Intents bridges several external signing standards such as BIP-322, TIP-191,
+and ERC-191. Each standard is represented by a small structure implementing the
+[`Payload`](https://near.github.io/intents/defuse_crypto/payload/trait.Payload.html)
+and [`SignedPayload`](https://near.github.io/intents/defuse_crypto/payload/trait.SignedPayload.html) traits.
+These implementations allow the engine to hash and verify messages from the
+different standards in a uniform way. They are used internally and are not part
+of a stable public API.
+
 ### The name "defuse"
 
 The name defuse is an old name for the smart contract that we use to execute intents. It is being phased out for NEAR Intents.

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -1,3 +1,11 @@
+//! Internal cryptographic primitives used across the Intents ecosystem.
+//!
+//! This crate defines lightweight traits such as [`Payload`] and
+//! [`SignedPayload`] that allow Intents to treat messages from different
+//! signing standards uniformly. Implementations of these traits live in
+//! companion crates like `tip191`, `erc191`, or `bip322` and are primarily
+//! intended for internal use.
+
 mod curve;
 mod payload;
 mod public_key;

--- a/crypto/src/payload.rs
+++ b/crypto/src/payload.rs
@@ -1,9 +1,28 @@
+//! Traits for hashing and verifying message payloads used within Intents.
+//!
+//! These traits provide a small abstraction layer over various signing
+//! standards supported by Intents. Each standard (e.g. BIP-322, TIP-191,
+//! ERC-191) defines its own structure that implements [`Payload`] and
+//! [`SignedPayload`]. The implementations expose a uniform API so the
+//! Intents engine can compute message hashes and verify signatures without
+//! knowing the concrete standard.
+
 pub use near_sdk::CryptoHash;
 
+/// Data that can be deterministically hashed for signing or verification.
+///
+/// Implementations of this trait typically represent a message formatted
+/// according to an external signing standard. The [`hash`] method returns
+/// the digest that should be signed or used for verification.
 pub trait Payload {
     fn hash(&self) -> CryptoHash;
 }
 
+/// Extension of [`Payload`] for types that include a signature.
+///
+/// Implementers verify the signature and, when successful, return the
+/// signer's public key. This trait is mainly intended for internal use and
+/// does not constitute a stable public API.
 pub trait SignedPayload: Payload {
     type PublicKey;
 


### PR DESCRIPTION
## Summary
- document Payload and SignedPayload traits in defuse-crypto
- describe internal payload traits in repository README

## Testing
- `cargo test -p defuse-crypto --target wasm32-unknown-unknown` *(fails: could not execute process — Exec format error)*

------
https://chatgpt.com/codex/tasks/task_b_68b9faa71fa4832cb345f68d89f131ec