### PR TITLE
fix: correct schema generator argument name

### DIFF
--- a/core/src/amounts.rs
+++ b/core/src/amounts.rs
@@ -250,8 +250,8 @@ mod abi {
             false
         }
 
-        fn json_schema(genenerator: &mut SchemaGenerator) -> Schema {
-            As::json_schema(genenerator)
+        fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+            As::json_schema(generator)
         }
     }
 }


### PR DESCRIPTION
## Summary
- rename json schema argument to `generator` for clarity

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68b9fa7b5288832c8b15a178fb27d15c