### PR TITLE
Fix TeeReader read_to_end buffer handling

### DIFF
--- a/io-utils/src/lib.rs
+++ b/io-utils/src/lib.rs
@@ -42,8 +42,9 @@ where
 
     /// Reads all remaining data into a buffer and writes it to the internal writer.
     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+        let len = buf.len();
         let n = self.reader.read_to_end(buf)?;
-        self.writer.write_all(&buf[..n])?;
+        self.writer.write_all(&buf[len..])?;
         Ok(n)
     }
 }


### PR DESCRIPTION
## Summary
- ensure `TeeReader::read_to_end` writes only newly read bytes to the tee'd writer

## Testing
- `cargo test -p defuse-io-utils`

------
https://chatgpt.com/codex/tasks/task_b_68b9fa7b5288832c8b15a178fb27d15c