### PR TITLE
fix: reject test configuration where emitted log length exceeds limit

### DIFF
--- a/tests/src/tests/defuse/tokens/nep245/mt_transfer_resolve_gas.rs
+++ b/tests/src/tests/defuse/tokens/nep245/mt_transfer_resolve_gas.rs
@@ -249,7 +249,7 @@ async fn run_resolve_gas_test(
 
     assert_eq!(
         longest_emited_log, expected_transfer_log,
-        "transfer log will does not match expected transfer log"
+        "transfer log does not match expected transfer log"
     );
 
     println!("{{{token_count}, {}}},", call_test_log.total_gas_burnt());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added validation to compute and enforce a maximum worst-case multi-token transfer log size before assertions run.
  * Pre-validates an expected transfer log size and asserts it matches the actual emitted logs to detect oversized payloads.
  * Improved diagnostics and output (token counts, max transfer amounts, per-call failure context, and longest-log reporting) for clearer test troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->