### PR TITLE
fix: implicit public key assumptions

### DIFF
--- a/defuse/src/contract/accounts/account/mod.rs
+++ b/defuse/src/contract/accounts/account/mod.rs
@@ -120,7 +120,7 @@ impl Account {
     }
 
     #[inline]
-    pub(crate) const fn is_implicit_public_key_removed(&self) -> bool {
+    const fn is_implicit_public_key_removed(&self) -> bool {
         self.flags
             .contains(AccountFlags::IMPLICIT_PUBLIC_KEY_REMOVED)
     }


### PR DESCRIPTION
dedicated helper method that will cause compilation error with every new intoroduced AccountType so that it needs to be quickfixed explicitally. 

basically is_implicit on account id doesnt mean that account has implicit public key  (as in the new `NearDeterministicAccount` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved implicit public-key detection to correctly handle NEAR implicit, Ethereum implicit, and named account types.

* **Tests**
  * Added unit tests covering implicit public-key removal and detection across those account types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->