### PR TITLE
release: defuse/v0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,7 +1021,7 @@ checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
 
 [[package]]
 name = "defuse"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/defuse/Cargo.toml
+++ b/defuse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "defuse"
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Version 0.4.2 is now available as a maintenance release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->