### PR TITLE
chore(global-deployer): update deployment addresses

### DIFF
--- a/global-deployer/README.md
+++ b/global-deployer/README.md
@@ -162,7 +162,7 @@ flowchart TD
 
 ### Deployed Instances
 
-The Global Deployer WASM is built from the [global-deployer/v0.1.0](https://github.com/near/intents/releases/tag/global-deployer%2Fv0.1.0) release. The code hash is the same on both networks:
+The Global Deployer WASM is built from the [global-deployer/v0.2.0](https://github.com/near/intents/releases/tag/global-deployer%2Fv0.2.0) release. The code hash is the same on both networks:
 
 **Code hash:** `8JK2g3kr7qCbRDBmoLx7c9Zrz9TxPdANP7ocbQGE2fqP`
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deployment docs to reference the new release (v0.2.0) and reorganized the Instances table for Testnet and Mainnet to show immutable-by-hash and mutable-by-account-id rows. Deployment records and transaction/address entries have been refreshed to reflect the current configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->