### PR TITLE
fix: remove redundant check refunds in actual refunds

### DIFF
--- a/contracts/defuse/src/contract/tokens/mod.rs
+++ b/contracts/defuse/src/contract/tokens/mod.rs
@@ -6,9 +6,7 @@ mod nep245;
 
 use super::Contract;
 use defuse_core::{DefuseError, Result, token_id::TokenId};
-use defuse_near_utils::{
-    Lock, REFUND_MEMO, UnwrapOrPanic, UnwrapOrPanicError, promise_result_checked_json_with_len,
-};
+use defuse_near_utils::{Lock, REFUND_MEMO, UnwrapOrPanic, promise_result_checked_json_with_len};
 use defuse_nep245::{MtBurnEvent, MtEvent, MtMintEvent};
 use itertools::{Either, Itertools};
 use near_sdk::{AccountId, AccountIdRef, Gas, env, json_types::U128};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified event emission during deposit resolution: removed an internal refund validation step and now emits burn events directly when applicable. No user-facing behavior or public API changes; this is an internal processing simplification with unchanged outward functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->