### PR TITLE
feat(wallet): erc191 variant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,6 +1352,7 @@ dependencies = [
  "defuse-borsh-utils",
  "defuse-crypto",
  "defuse-deadline",
+ "defuse-erc191",
  "defuse-serde-utils",
  "defuse-test-utils",
  "defuse-webauthn",

--- a/contracts/wallet/Cargo.toml
+++ b/contracts/wallet/Cargo.toml
@@ -23,6 +23,7 @@ near-sdk = { workspace = true, features = ["deterministic-account-ids"] }
 thiserror.workspace = true
 
 defuse-crypto = { workspace = true, default-features = false, optional = true }
+defuse-erc191 = { workspace = true, optional = true }
 defuse-webauthn = { workspace = true, default-features = false, optional = true }
 
 arbitrary = { workspace = true, features = ["derive"], optional = true }
@@ -34,6 +35,7 @@ abi = [
   "defuse-borsh-utils/abi",
   "defuse-crypto?/abi",
   "defuse-deadline/abi",
+  "defuse-erc191?/abi",
   "defuse-serde-utils/abi",
   "defuse-webauthn?/abi",
   "near-sdk/abi",
@@ -49,12 +51,15 @@ webauthn = ["dep:defuse-webauthn"]
 # So only extensions can execute requests via `w_execute_extension()`.
 contract = []
 
+# Raw ed25519 signature:
+ed25519 = ["defuse-crypto/ed25519"]
+
 # Webauthn (a.k.a passkey) variants:
 webauthn-ed25519 = ["defuse-webauthn/ed25519", "webauthn"]
 webauthn-p256 = ["defuse-webauthn/p256", "webauthn"]
 
-# Raw ed25519 signature:
-ed25519 = ["defuse-crypto/ed25519"]
+# ERC-191 (a.k.a. `personal_sign`)
+erc191 = ["defuse-crypto/secp256k1", "defuse-erc191"]
 
 [package.metadata.near.reproducible_build]
 image = "sourcescan/cargo-near:0.19.0-rust-1.86.0"
@@ -99,6 +104,21 @@ container_build_command = [
   "--no-default-features",
   "--features=contract,webauthn-p256",
   "--abi-features=abi,contract,webauthn-p256",
+]
+
+[package.metadata.near.reproducible_build.variant.erc191]
+image = "sourcescan/cargo-near:0.19.0-rust-1.86.0"
+image_digest = "sha256:772638e343baeeea24e49062c7d424274f3441452cc06ce97fc4e5695b19fecc"
+passed_env = []
+container_build_command = [
+  "cargo",
+  "near",
+  "build",
+  "non-reproducible-wasm",
+  "--locked",
+  "--no-default-features",
+  "--features=contract,erc191",
+  "--abi-features=abi,contract,erc191",
 ]
 
 [package.metadata.near.reproducible_build.variant.no-auth]

--- a/contracts/wallet/src/contract/impl_.rs
+++ b/contracts/wallet/src/contract/impl_.rs
@@ -159,7 +159,19 @@ contract_impl! {
             /// 2. This reduces length of the `proof` submitted on-chain.
             type SigningStandard = Borsh<DomainPrefix<Sha256<Webauthn<P256>>>>;
         }
+    }
 
+    #[cfg_attr(
+        feature = "erc191",
+        near(contract_metadata(
+            standard(standard = "wallet-erc191", version = "1.0.0")
+        ))
+    )] {
+        use crate::signature::erc191::Erc191;
+
+        impl ContractImpl for Contract {
+            type SigningStandard = Erc191;
+        }
     }
 }
 

--- a/contracts/wallet/src/signature/erc191.rs
+++ b/contracts/wallet/src/signature/erc191.rs
@@ -1,16 +1,13 @@
 use crate::signature::SigningStandard;
 use defuse_crypto::{Secp256k1PublicKey, SignedPayload};
 use defuse_erc191::SignedErc191Payload;
-use near_sdk::{
-    serde::{Serialize, de::DeserializeOwned},
-    serde_json,
-};
+use near_sdk::{serde::de::DeserializeOwned, serde_json};
 
 pub struct Erc191;
 
 impl<M> SigningStandard<&M> for Erc191
 where
-    M: Serialize + DeserializeOwned + PartialEq,
+    M: DeserializeOwned + PartialEq,
 {
     type PublicKey = Secp256k1PublicKey;
 

--- a/contracts/wallet/src/signature/erc191.rs
+++ b/contracts/wallet/src/signature/erc191.rs
@@ -1,0 +1,40 @@
+use crate::signature::SigningStandard;
+use defuse_crypto::{Secp256k1PublicKey, SignedPayload};
+use defuse_erc191::SignedErc191Payload;
+use near_sdk::{
+    serde::{Serialize, de::DeserializeOwned},
+    serde_json,
+};
+
+pub struct Erc191;
+
+impl<M> SigningStandard<&M> for Erc191
+where
+    M: Serialize + DeserializeOwned + PartialEq,
+{
+    type PublicKey = Secp256k1PublicKey;
+
+    fn verify(msg: &M, public_key: &Self::PublicKey, signature: &str) -> bool {
+        let Ok(signature) = serde_json::from_str::<SignedErc191Payload>(signature) else {
+            return false;
+        };
+
+        // deserialize the payload as message
+        let Ok(payload) = serde_json::from_str::<M>(&signature.payload.0) else {
+            return false;
+        };
+
+        // check that signed the same message
+        if msg != &payload {
+            return false;
+        }
+
+        // recover public key from signature
+        let Some(recovered_pk) = signature.verify() else {
+            return false;
+        };
+
+        // check that recovered public key matches contract's one
+        recovered_pk == public_key.0
+    }
+}

--- a/contracts/wallet/src/signature/mod.rs
+++ b/contracts/wallet/src/signature/mod.rs
@@ -2,6 +2,8 @@ mod borsh;
 mod domain;
 #[cfg(feature = "ed25519")]
 pub mod ed25519;
+#[cfg(feature = "erc191")]
+pub mod erc191;
 mod hash;
 pub mod no_sign;
 

--- a/crates/signatures/erc191/Cargo.toml
+++ b/crates/signatures/erc191/Cargo.toml
@@ -11,6 +11,9 @@ defuse-crypto = { workspace = true, default-features = false, features = ["secp2
 impl-tools.workspace = true
 near-sdk.workspace = true
 
+[features]
+abi = ["defuse-crypto/abi", "near-sdk/abi"]
+
 [dev-dependencies]
 defuse-test-utils.workspace = true
 hex-literal.workspace = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ERC-191 (personal_sign) signature verification added to the wallet, allowing verification of personal-style signatures.
  * Secp256k1-based signing/public-key verification supported as an additional signing standard.
  * New optional feature flag lets deployments enable ERC-191 signing and related ABI support without affecting existing signing options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->