### PR TITLE
chore: use near-plugins from crates-io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3857,7 +3857,8 @@ dependencies = [
 [[package]]
 name = "near-plugins"
 version = "0.5.1"
-source = "git+https://github.com/Near-One/near-plugins?tag=v0.5.1#312e016e0574d5756f6eba37acc82d9a237b2e3e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "398b94e104f7d6cc350a3cfa5134cf0a81a2c237b85df6820b18c2eca763fc0e"
 dependencies = [
  "bitflags 1.3.2",
  "near-plugins-derive",
@@ -3868,7 +3869,8 @@ dependencies = [
 [[package]]
 name = "near-plugins-derive"
 version = "0.5.1"
-source = "git+https://github.com/Near-One/near-plugins?tag=v0.5.1#312e016e0574d5756f6eba37acc82d9a237b2e3e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90004ce76905fc3b7d501c729b8682a48f8ba58faba8c8e5bca1958d5051cbcf"
 dependencies = [
  "darling 0.20.11",
  "proc-macro-crate 0.1.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ near-contract-standards = "5.24"
 near-crypto = "0.34.1"
 near-kit = { version = "0.8.0", default-features = false }
 near-openapi-types = "0.6.0"
-near-plugins = { git = "https://github.com/Near-One/near-plugins", tag = "v0.5.1" }
+near-plugins = "0.5.1"
 near-sandbox = "0.3.5"
 near-sdk = "5.26.1"
 near-workspaces = "0.22"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration to use v0.5.1 from the package registry, improving build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->