### PR TITLE
fix!(wallet): idempotent ops

### DIFF
--- a/contracts/wallet/src/contract/mod.rs
+++ b/contracts/wallet/src/contract/mod.rs
@@ -127,38 +127,44 @@ impl Contract {
     }
 
     fn set_signature_mode(&mut self, enable: bool, actor: Actor<'_>) -> Result<()> {
-        if self.signature_enabled != enable {
-            self.signature_enabled = enable;
-            WalletEvent::SignatureModeSet {
-                enabled: enable,
-                by: actor,
-            }
-            .emit();
+        if self.signature_enabled == enable {
+            return Ok(());
         }
+
+        self.signature_enabled = enable;
+        WalletEvent::SignatureModeSet {
+            enabled: enable,
+            by: actor,
+        }
+        .emit();
 
         self.check_lockout()
     }
 
     fn add_extension(&mut self, account_id: AccountId, actor: Actor<'_>) -> Result<()> {
-        if self.extensions.insert(account_id.clone()) {
-            WalletEvent::ExtensionAdded {
-                account_id: (&account_id).into(),
-                by: actor,
-            }
-            .emit();
+        if !self.extensions.insert(account_id.clone()) {
+            return Ok(());
         }
+
+        WalletEvent::ExtensionAdded {
+            account_id: (&account_id).into(),
+            by: actor,
+        }
+        .emit();
 
         Ok(())
     }
 
     fn remove_extension(&mut self, account_id: AccountId, actor: Actor<'_>) -> Result<()> {
-        if self.extensions.remove(&account_id) {
-            WalletEvent::ExtensionRemoved {
-                account_id: (&account_id).into(),
-                by: actor,
-            }
-            .emit();
+        if !self.extensions.remove(&account_id) {
+            return Ok(());
         }
+
+        WalletEvent::ExtensionRemoved {
+            account_id: (&account_id).into(),
+            by: actor,
+        }
+        .emit();
 
         self.check_lockout()
     }

--- a/contracts/wallet/src/contract/mod.rs
+++ b/contracts/wallet/src/contract/mod.rs
@@ -123,52 +123,41 @@ impl Contract {
             WalletOp::SetSignatureMode { enable } => self.set_signature_mode(enable, actor),
             WalletOp::AddExtension { account_id } => self.add_extension(account_id, actor),
             WalletOp::RemoveExtension { account_id } => self.remove_extension(account_id, actor),
-
-            WalletOp::Custom { .. } => env::panic_str("custom ops are not supported"),
         }
     }
 
     fn set_signature_mode(&mut self, enable: bool, actor: Actor<'_>) -> Result<()> {
-        // emit first to help for debugging
-        WalletEvent::SignatureModeSet {
-            enabled: enable,
-            by: actor,
+        if self.signature_enabled != enable {
+            self.signature_enabled = enable;
+            WalletEvent::SignatureModeSet {
+                enabled: enable,
+                by: actor,
+            }
+            .emit();
         }
-        .emit();
-
-        if self.signature_enabled == enable {
-            return Err(Error::ThisSignatureModeAlreadySet);
-        }
-        self.signature_enabled = enable;
 
         self.check_lockout()
     }
 
     fn add_extension(&mut self, account_id: AccountId, actor: Actor<'_>) -> Result<()> {
-        // emit first to help for debugging
-        WalletEvent::ExtensionAdded {
-            account_id: (&account_id).into(),
-            by: actor,
-        }
-        .emit();
-
-        if !self.extensions.insert(account_id.clone()) {
-            return Err(Error::ExtensionEnabled(account_id));
+        if self.extensions.insert(account_id.clone()) {
+            WalletEvent::ExtensionAdded {
+                account_id: (&account_id).into(),
+                by: actor,
+            }
+            .emit();
         }
 
         Ok(())
     }
 
     fn remove_extension(&mut self, account_id: AccountId, actor: Actor<'_>) -> Result<()> {
-        // emit first to help for debugging
-        WalletEvent::ExtensionRemoved {
-            account_id: (&account_id).into(),
-            by: actor,
-        }
-        .emit();
-
-        if !self.extensions.remove(&account_id) {
-            return Err(Error::ExtensionNotEnabled(account_id));
+        if self.extensions.remove(&account_id) {
+            WalletEvent::ExtensionRemoved {
+                account_id: (&account_id).into(),
+                by: actor,
+            }
+            .emit();
         }
 
         self.check_lockout()

--- a/contracts/wallet/src/contract/mod.rs
+++ b/contracts/wallet/src/contract/mod.rs
@@ -121,8 +121,11 @@ impl Contract {
     fn execute_op(&mut self, op: WalletOp, actor: Actor<'_>) -> Result<()> {
         match op {
             WalletOp::SetSignatureMode { enable } => self.set_signature_mode(enable, actor),
-            WalletOp::AddExtension { account_id } => self.add_extension(account_id, actor),
-            WalletOp::RemoveExtension { account_id } => self.remove_extension(account_id, actor),
+            WalletOp::AddExtension { account_id } => {
+                self.add_extension(&account_id, actor);
+                Ok(())
+            }
+            WalletOp::RemoveExtension { account_id } => self.remove_extension(&account_id, actor),
         }
     }
 
@@ -130,24 +133,11 @@ impl Contract {
         if self.signature_enabled == enable {
             return Ok(());
         }
-
         self.signature_enabled = enable;
+        self.check_lockout()?;
+
         WalletEvent::SignatureModeSet {
             enabled: enable,
-            by: actor,
-        }
-        .emit();
-
-        self.check_lockout()
-    }
-
-    fn add_extension(&mut self, account_id: AccountId, actor: Actor<'_>) -> Result<()> {
-        if !self.extensions.insert(account_id.clone()) {
-            return Ok(());
-        }
-
-        WalletEvent::ExtensionAdded {
-            account_id: (&account_id).into(),
             by: actor,
         }
         .emit();
@@ -155,18 +145,31 @@ impl Contract {
         Ok(())
     }
 
-    fn remove_extension(&mut self, account_id: AccountId, actor: Actor<'_>) -> Result<()> {
-        if !self.extensions.remove(&account_id) {
-            return Ok(());
+    fn add_extension(&mut self, account_id: &AccountIdRef, actor: Actor<'_>) {
+        if !self.extensions.insert(account_id.to_owned()) {
+            return;
         }
 
+        WalletEvent::ExtensionAdded {
+            account_id: account_id.into(),
+            by: actor,
+        }
+        .emit();
+    }
+
+    fn remove_extension(&mut self, account_id: &AccountIdRef, actor: Actor<'_>) -> Result<()> {
+        if !self.extensions.remove(account_id) {
+            return Ok(());
+        }
+        self.check_lockout()?;
+
         WalletEvent::ExtensionRemoved {
-            account_id: (&account_id).into(),
+            account_id: account_id.into(),
             by: actor,
         }
         .emit();
 
-        self.check_lockout()
+        Ok(())
     }
 
     fn check_extension_enabled(&self, account_id: &AccountIdRef) -> Result<()> {

--- a/contracts/wallet/src/error.rs
+++ b/contracts/wallet/src/error.rs
@@ -8,9 +8,6 @@ pub enum Error {
     #[error("already executed")]
     AlreadyExecuted,
 
-    #[error("extension '{0}' is already enabled")]
-    ExtensionEnabled(AccountId),
-
     #[error("extension '{0}' is not enabled")]
     ExtensionNotEnabled(AccountId),
 
@@ -34,7 +31,4 @@ pub enum Error {
 
     #[error("signature is disabled")]
     SignatureDisabled,
-
-    #[error("this signature mode is already set")]
-    ThisSignatureModeAlreadySet,
 }

--- a/contracts/wallet/src/lib.rs
+++ b/contracts/wallet/src/lib.rs
@@ -27,9 +27,9 @@ pub trait Wallet {
     ///
     /// SHOULD accept ANY attached deposit.
     ///
-    /// MUST fail in case where the `signed.request` was not executed
+    /// MUST fail in case where the `msg.request` was not executed
     /// due to various reasons, including:
-    ///   * `signed` data is invalid
+    ///   * `msg` is invalid
     ///   * `proof` is invalid
     ///   * signature is disabled
     ///   * nonce is already used
@@ -37,7 +37,7 @@ pub trait Wallet {
 
     /// Execute request from an enabled extension.
     ///
-    /// * SHOULD accept ANY non-zero attached deposit
+    /// * SHOULD accept ANY **non-zero** attached deposit
     /// * MUST panic if zero deposit was attached
     /// * MUST panic if [`predecessor_account_id`](near_sdk::env::predecessor_account_id)
     ///   extension is not enabled

--- a/contracts/wallet/src/request/ops.rs
+++ b/contracts/wallet/src/request/ops.rs
@@ -4,7 +4,7 @@ use near_sdk::{AccountId, near};
 ///
 /// # Idempotence
 ///
-/// Currently, all operations are idempotent, i.e. they expess an intent on
+/// Currently, all operations are idempotent, i.e. they express an intent on
 /// the final state rather than "compare-and-swap" semantics. If ever needed,
 /// we can add more `require_*` operations, e.g.
 /// `RequireExtensionEnabled { account_id }`.

--- a/contracts/wallet/src/request/ops.rs
+++ b/contracts/wallet/src/request/ops.rs
@@ -1,5 +1,18 @@
 use near_sdk::{AccountId, near};
 
+/// An operation to perform on wallet-contract's state.
+///
+/// # Idempotence
+///
+/// Currently, all operations are idempotent, i.e. they expess an intent on
+/// the final state rather than "compare-and-swap" semantics. If ever needed,
+/// we can add more `require_*` operations, e.g.
+/// `RequireExtensionEnabled { account_id }`.
+///
+/// We could have added an optional `strict` flag to each operation. However,
+/// it would not only break borsh serialization, but it's also less expressive
+/// than potential `require_*` variants: one might want to only atomically
+/// require the contract to be in a specific state, without mutating it.
 #[cfg_attr(any(feature = "arbitrary", test), derive(arbitrary::Arbitrary))]
 #[near(serializers = [borsh(use_discriminant = true), json])]
 #[serde(tag = "op", rename_all = "snake_case")]
@@ -12,13 +25,13 @@ pub enum WalletOp {
     /// signature mode is already in this state.
     SetSignatureMode { enable: bool } = 0,
 
-    /// Add extension with given `AccountId`.
+    /// Add an extension with given `AccountId`.
     ///
     /// This operation is idempotent, i.e. no error will be raised if
     /// given extension is already enabled.
     AddExtension { account_id: AccountId } = 1,
 
-    /// Remove extension with given `AccountId`.
+    /// Remove an extension with given `AccountId`.
     ///
     /// This operation is idempotent, i.e. no error will be raised if
     /// given extension is not currently enabled.

--- a/contracts/wallet/src/request/ops.rs
+++ b/contracts/wallet/src/request/ops.rs
@@ -6,7 +6,21 @@ use near_sdk::{AccountId, near};
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(u8)]
 pub enum WalletOp {
+    /// Enable or disable authentication by signature.
+    ///
+    /// This operation is idempotent, i.e. no error will be raised if
+    /// signature mode is already in this state.
     SetSignatureMode { enable: bool } = 0,
+
+    /// Add extension with given `AccountId`.
+    ///
+    /// This operation is idempotent, i.e. no error will be raised if
+    /// given extension is already enabled.
     AddExtension { account_id: AccountId } = 1,
+
+    /// Remove extension with given `AccountId`.
+    ///
+    /// This operation is idempotent, i.e. no error will be raised if
+    /// given extension is not currently enabled.
     RemoveExtension { account_id: AccountId } = 2,
 }

--- a/contracts/wallet/src/request/ops.rs
+++ b/contracts/wallet/src/request/ops.rs
@@ -1,4 +1,4 @@
-use near_sdk::{AccountId, near, serde_with::base64::Base64};
+use near_sdk::{AccountId, near};
 
 #[cfg_attr(any(feature = "arbitrary", test), derive(arbitrary::Arbitrary))]
 #[near(serializers = [borsh(use_discriminant = true), json])]
@@ -6,23 +6,7 @@ use near_sdk::{AccountId, near, serde_with::base64::Base64};
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(u8)]
 pub enum WalletOp {
-    SetSignatureMode {
-        enable: bool,
-    } = 0,
-    AddExtension {
-        account_id: AccountId,
-    } = 1,
-    RemoveExtension {
-        account_id: AccountId,
-    } = 2,
-
-    /// Custom op for third-party implementations.
-    Custom {
-        #[cfg_attr(
-            all(feature = "abi", not(target_arch = "wasm32")),
-            schemars(with = "String")
-        )]
-        #[serde_as(as = "Base64")]
-        args: Vec<u8>,
-    } = u8::MAX - 1,
+    SetSignatureMode { enable: bool } = 0,
+    AddExtension { account_id: AccountId } = 1,
+    RemoveExtension { account_id: AccountId } = 2,
 }


### PR DESCRIPTION
This PR makes all current ops to have idempotent semantics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wallet operations (`SetSignatureMode`, `AddExtension`, `RemoveExtension`) are now idempotent—repeating the same operation returns success instead of an error.
  * Events are only emitted when actual state changes occur, reducing unnecessary event noise.

* **Removals**
  * Custom wallet operations are no longer supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->