### PR TITLE
chore: remove near-sdk dep in primitive types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,11 +1420,15 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "bnum",
+ "borsh",
+ "cfg_eval",
  "defuse-map-utils",
  "hex-literal",
- "near-sdk",
  "num-traits",
  "rstest",
+ "schemars 0.8.22",
+ "serde",
+ "serde_with",
 ]
 
 [[package]]
@@ -1513,9 +1517,13 @@ name = "defuse-decimal"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
+ "borsh",
+ "cfg_eval",
  "defuse-num-utils",
- "near-sdk",
  "rstest",
+ "schemars 0.8.22",
+ "serde",
+ "serde_with",
  "thiserror 2.0.18",
 ]
 
@@ -1562,8 +1570,12 @@ dependencies = [
 name = "defuse-fees"
 version = "0.1.0"
 dependencies = [
+ "borsh",
+ "cfg_eval",
  "defuse-num-utils",
- "near-sdk",
+ "schemars 0.8.22",
+ "serde",
+ "serde_with",
  "thiserror 2.0.18",
 ]
 

--- a/contracts/defuse/Cargo.toml
+++ b/contracts/defuse/Cargo.toml
@@ -69,6 +69,8 @@ container_build_command = [
 abi = ["defuse-core/abi", "near-sdk/abi"]
 arbitrary = ["defuse-core/arbitrary", "dep:arbitrary"]
 contract = [
+  "defuse-bitmap/borsh",
+  "defuse-bitmap/serde",
   "dep:bitflags",
   "dep:defuse-bitmap",
   "dep:defuse-borsh-utils",

--- a/contracts/defuse/core/Cargo.toml
+++ b/contracts/defuse/core/Cargo.toml
@@ -6,11 +6,11 @@ rust-version.workspace = true
 repository.workspace = true
 
 [dependencies]
-defuse-bitmap.workspace = true
+defuse-bitmap = { workspace = true, features = ["borsh", "serde"] }
 defuse-crypto = { workspace = true, features = ["ed25519", "secp256k1", "p256"] }
 defuse-deadline.workspace = true
 defuse-erc191.workspace = true
-defuse-fees.workspace = true
+defuse-fees = { workspace = true, features = ["borsh", "serde"] }
 defuse-map-utils.workspace = true
 defuse-near-utils.workspace = true
 defuse-nep245.workspace = true
@@ -37,8 +37,10 @@ arbitrary = { workspace = true, optional = true }
 
 [features]
 abi = [
+  "defuse-bitmap/abi",
   "defuse-crypto/abi",
   "defuse-deadline/abi",
+  "defuse-fees/abi",
   "defuse-serde-utils/abi",
   "defuse-token-id/abi",
   "defuse-ton-connect/abi",

--- a/contracts/escrow-swap/Cargo.toml
+++ b/contracts/escrow-swap/Cargo.toml
@@ -29,8 +29,8 @@ container_build_command = [
 [dependencies]
 defuse-borsh-utils = { workspace = true, features = ["chrono"] }
 defuse-deadline.workspace = true
-defuse-decimal.workspace = true
-defuse-fees.workspace = true
+defuse-decimal = { workspace = true, features = ["borsh", "serde"] }
+defuse-fees = { workspace = true, features = ["borsh", "serde"] }
 defuse-nep245.workspace = true
 defuse-num-utils.workspace = true
 defuse-token-id.workspace = true
@@ -65,6 +65,7 @@ nep245 = ["defuse-token-id/nep245"]
 abi = [
   "defuse-deadline/abi",
   "defuse-decimal/abi",
+  "defuse-fees/abi",
   "defuse-token-id/abi",
   "near-sdk/abi",
   "serde_with/schemars_0_8",

--- a/contracts/wallet/Cargo.toml
+++ b/contracts/wallet/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib", "rlib"]
 workspace = true
 
 [dependencies]
-defuse-bitmap.workspace = true
+defuse-bitmap = { workspace = true, features = ["borsh", "serde"] }
 defuse-borsh-utils.workspace = true
 defuse-deadline.workspace = true
 defuse-serde-utils = { workspace = true, features = ["base58"] }

--- a/crates/bitmap/Cargo.toml
+++ b/crates/bitmap/Cargo.toml
@@ -8,19 +8,25 @@ repository.workspace = true
 [dependencies]
 defuse-map-utils.workspace = true
 
-near-sdk.workspace = true
 num-traits.workspace = true
+
+borsh = { workspace = true, optional = true }
+cfg_eval = { workspace = true, optional = true }
+schemars = { workspace = true, optional = true }
+serde = { workspace = true, features = ["derive"], optional = true }
+serde_with = { workspace = true, optional = true }
 
 arbitrary = { workspace = true, optional = true }
 
 [features]
-abi = ["near-sdk/abi"]
+borsh = ["dep:borsh"]
+serde = ["dep:cfg_eval", "dep:serde", "dep:serde_with"]
+abi = ["borsh/unstable__schema", "dep:schemars"]
 arbitrary = ["dep:arbitrary"]
 
 [dev-dependencies]
 bnum.workspace = true
 hex-literal.workspace = true
-near-sdk = { workspace = true, features = ["unit-testing"] }
 rstest.workspace = true
 
 [lints]

--- a/crates/bitmap/src/b256.rs
+++ b/crates/bitmap/src/b256.rs
@@ -1,13 +1,23 @@
 use defuse_map_utils::{IterableMap, Map};
-use near_sdk::near;
 
 pub type U256 = [u8; 32];
 pub type U248 = [u8; 31];
 
-/// 256-bit map.  
+/// 256-bit map.
 /// See [permit2 nonce schema](https://docs.uniswap.org/contracts/permit2/reference/signature-transfer#nonce-schema)
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[near(serializers = [borsh, json])]
+#[cfg_attr(
+    feature = "borsh",
+    derive(::borsh::BorshSerialize, ::borsh::BorshDeserialize),
+    cfg_attr(feature = "abi", derive(::borsh::BorshSchema))
+)]
+#[cfg_attr(
+    feature = "serde",
+    ::cfg_eval::cfg_eval,
+    ::serde_with::serde_as,
+    derive(::serde::Serialize, ::serde::Deserialize),
+    cfg_attr(feature = "abi", derive(::schemars::JsonSchema))
+)]
 #[derive(Debug, Clone, Default)]
 #[repr(transparent)]
 pub struct BitMap256<T: Map<K = U248, V = U256>>(T);

--- a/crates/bitmap/src/lib.rs
+++ b/crates/bitmap/src/lib.rs
@@ -5,11 +5,21 @@ pub use self::b256::*;
 use core::ops::{DerefMut, RangeInclusive, Shl};
 
 use defuse_map_utils::{IterableMap, Map, cleanup::DefaultMap};
-use near_sdk::near;
 use num_traits::{One, PrimInt, Zero};
 
 /// Bitmap for primitive types
-#[near(serializers = [borsh, json])]
+#[cfg_attr(
+    feature = "borsh",
+    derive(::borsh::BorshSerialize, ::borsh::BorshDeserialize),
+    cfg_attr(feature = "abi", derive(::borsh::BorshSchema))
+)]
+#[cfg_attr(
+    feature = "serde",
+    ::cfg_eval::cfg_eval,
+    ::serde_with::serde_as,
+    derive(::serde::Serialize, ::serde::Deserialize),
+    cfg_attr(feature = "abi", derive(::schemars::JsonSchema))
+)]
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 pub struct BitMap<M>(M);

--- a/crates/primitives/decimal/Cargo.toml
+++ b/crates/primitives/decimal/Cargo.toml
@@ -9,17 +9,23 @@ repository.workspace = true
 workspace = true
 
 [features]
-abi = ["near-sdk/abi"]
+borsh = ["dep:borsh"]
+serde = ["dep:cfg_eval", "dep:serde", "dep:serde_with"]
+abi = ["borsh/unstable__schema", "dep:schemars"]
 arbitrary = ["dep:arbitrary"]
 
 [dependencies]
 defuse-num-utils.workspace = true
 
-near-sdk.workspace = true
 thiserror.workspace = true
+
+borsh = { workspace = true, optional = true }
+cfg_eval = { workspace = true, optional = true }
+schemars = { workspace = true, optional = true }
+serde = { workspace = true, features = ["derive"], optional = true }
+serde_with = { workspace = true, optional = true }
 
 arbitrary = { workspace = true, optional = true }
 
 [dev-dependencies]
-near-sdk = { workspace = true, features = ["non-contract-usage"] }
 rstest.workspace = true

--- a/crates/primitives/decimal/src/lib.rs
+++ b/crates/primitives/decimal/src/lib.rs
@@ -5,24 +5,28 @@ mod str;
 
 pub use self::str::*;
 
-use near_sdk::{
-    borsh::{BorshDeserialize, BorshSerialize, io},
-    serde_with::{DeserializeFromStr, SerializeDisplay},
-};
+#[cfg(feature = "borsh")]
+use ::borsh::{BorshDeserialize, io};
 
 /// Floating point unsigned decimal price, i.e. dst per 1 src
 /// always reduced (i.e. normalized)
 #[cfg_attr(
-    all(feature = "abi", not(target_arch = "wasm32")),
-    derive(near_sdk::NearSchema),
-    abi(json, borsh),
-    schemars(with = "String")
+    feature = "borsh",
+    derive(::borsh::BorshSerialize),
+    cfg_attr(feature = "abi", derive(::borsh::BorshSchema))
 )]
-#[derive(
-    Clone, Copy, PartialEq, Eq, Hash, BorshSerialize, SerializeDisplay, DeserializeFromStr,
+#[cfg_attr(
+    feature = "serde",
+    ::cfg_eval::cfg_eval,
+    ::serde_with::serde_as,
+    derive(::serde_with::SerializeDisplay, ::serde_with::DeserializeFromStr),
+    cfg_attr(
+        feature = "abi",
+        derive(::schemars::JsonSchema),
+        schemars(with = "String")
+    )
 )]
-#[borsh(crate = "::near_sdk::borsh")]
-#[serde_with(crate = "::near_sdk::serde_with")]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct UD128(u8, u128);
 
 impl UD128 {
@@ -96,9 +100,10 @@ impl From<u128> for UD128 {
     }
 }
 
-impl BorshDeserialize for UD128 {
+#[cfg(feature = "borsh")]
+impl ::borsh::BorshDeserialize for UD128 {
     fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-        let (decimals, digits) = BorshDeserialize::deserialize_reader(reader)?;
+        let (decimals, digits) = ::borsh::BorshDeserialize::deserialize_reader(reader)?;
         Self::new(decimals, digits).ok_or_else(|| io::ErrorKind::InvalidData.into())
     }
 }

--- a/crates/primitives/fees/Cargo.toml
+++ b/crates/primitives/fees/Cargo.toml
@@ -8,8 +8,18 @@ repository.workspace = true
 [lints]
 workspace = true
 
+[features]
+borsh = ["dep:borsh"]
+serde = ["dep:cfg_eval", "dep:serde", "dep:serde_with"]
+abi = ["borsh/unstable__schema", "dep:schemars"]
+
 [dependencies]
 defuse-num-utils.workspace = true
 
-near-sdk.workspace = true
 thiserror.workspace = true
+
+borsh = { workspace = true, optional = true }
+cfg_eval = { workspace = true, optional = true }
+schemars = { workspace = true, optional = true }
+serde = { workspace = true, features = ["derive"], optional = true }
+serde_with = { workspace = true, optional = true }

--- a/crates/primitives/fees/src/lib.rs
+++ b/crates/primitives/fees/src/lib.rs
@@ -4,19 +4,23 @@ use core::{
 };
 
 use defuse_num_utils::{CheckedAdd, CheckedMulDiv, CheckedSub};
-use near_sdk::{
-    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
-    near,
-};
 use thiserror::Error as ThisError;
 
 /// 1 pip == 1/100th of bip == 0.0001%
-#[near(serializers = [json])]
-#[serde(try_from = "u32")]
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, BorshSerialize, BorshSchema,
+#[cfg_attr(
+    feature = "borsh",
+    derive(::borsh::BorshSerialize),
+    cfg_attr(feature = "abi", derive(::borsh::BorshSchema))
 )]
-#[borsh(crate = "::near_sdk::borsh")]
+#[cfg_attr(
+    feature = "serde",
+    ::cfg_eval::cfg_eval,
+    ::serde_with::serde_as,
+    derive(::serde::Serialize, ::serde::Deserialize),
+    cfg_attr(feature = "abi", derive(::schemars::JsonSchema))
+)]
+#[cfg_attr(feature = "serde", serde(try_from = "u32"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub struct Pips(u32);
 
 impl Pips {
@@ -198,7 +202,8 @@ impl TryFrom<u32> for Pips {
 #[error("out of range: 0..={}", Pips::MAX.as_pips())]
 pub struct PipsOutOfRange;
 
-impl BorshDeserialize for Pips {
+#[cfg(feature = "borsh")]
+impl ::borsh::BorshDeserialize for Pips {
     fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
         let pips = u32::deserialize_reader(reader)?;
         Self::from_pips(pips).ok_or_else(|| {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency and feature configurations to improve serialization flexibility across contracts and primitives crates.
  * Restructured build infrastructure for enhanced modularity and configurability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->