### PR TITLE
chore(digest): `Sha3_256` and `Sha3_512` wrappers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
+ "zeroize",
 ]
 
 [[package]]
@@ -1510,6 +1511,7 @@ dependencies = [
  "rstest",
  "sha2 0.11.0",
  "sha3 0.11.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -1601,6 +1603,7 @@ version = "0.1.0"
 dependencies = [
  "borsh",
  "curve25519-dalek",
+ "defuse-digest",
  "defuse-kdf",
  "defuse-kdf-crypto",
  "digest 0.11.3",
@@ -1611,7 +1614,6 @@ dependencies = [
  "impl-tools",
  "k256",
  "rstest",
- "sha3 0.11.0",
 ]
 
 [[package]]
@@ -1628,12 +1630,12 @@ dependencies = [
 name = "defuse-kdf-mpc"
 version = "0.1.0"
 dependencies = [
+ "defuse-digest",
  "defuse-kdf",
  "hex-literal",
  "impl-tools",
  "near-account-id",
  "rstest",
- "sha3 0.11.0",
 ]
 
 [[package]]
@@ -2147,6 +2149,7 @@ dependencies = [
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,6 +1613,7 @@ dependencies = [
  "hex-literal",
  "impl-tools",
  "k256",
+ "near-sdk",
  "rstest",
 ]
 
@@ -1635,6 +1636,7 @@ dependencies = [
  "hex-literal",
  "impl-tools",
  "near-account-id",
+ "near-sdk",
  "rstest",
 ]
 
@@ -1679,6 +1681,7 @@ dependencies = [
  "digest-io",
  "impl-tools",
  "near-api",
+ "near-sdk",
  "schemars 0.8.22",
  "serde",
  "serde_json",

--- a/crates/digest/Cargo.toml
+++ b/crates/digest/Cargo.toml
@@ -10,10 +10,12 @@ repository.workspace = true
 [dependencies]
 digest.workspace = true
 
+sha3 = { workspace = true, optional = true }
+zeroize = { workspace = true, features = ["derive"], optional = true }
+
 [target.'cfg(not(near))'.dependencies]
 ripemd = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
-sha3 = { workspace = true, optional = true }
 
 [target.'cfg(near)'.dependencies]
 near-sdk-env.workspace = true
@@ -24,8 +26,16 @@ ripemd = ["dep:ripemd"]
 sha2 = ["dep:sha2"]
 sha3 = ["dep:sha3"]
 
+zeroize = [
+  "dep:zeroize",
+  "digest/zeroize",
+  "ripemd?/zeroize",
+  "sha2?/zeroize",
+  "sha3?/zeroize",
+]
+
 [dev-dependencies]
-defuse-digest = { path = ".", features = ["ripemd", "sha2", "sha3"] }
+defuse-digest = { path = ".", features = ["ripemd", "sha2", "sha3", "zeroize"] }
 
 hex-literal.workspace = true
 rstest.workspace = true

--- a/crates/digest/src/lib.rs
+++ b/crates/digest/src/lib.rs
@@ -40,6 +40,9 @@ macro_rules! digest_cfg {
         }
 
         impl ::digest::HashMarker for $name {}
+
+        #[cfg(feature = "zeroize")]
+        impl ::zeroize::ZeroizeOnDrop for $name {}
     };
 }
 pub(crate) use digest_cfg;

--- a/crates/digest/src/sha3/mod.rs
+++ b/crates/digest/src/sha3/mod.rs
@@ -17,6 +17,20 @@ digest_cfg! {
     }
 }
 
+digest_cfg! {
+    pub struct Sha3_256 {
+        // TODO: cfg(near)
+        _ => ::sha3::Sha3_256,
+    }
+}
+
+digest_cfg! {
+    pub struct Sha3_512 {
+        // TODO: cfg(near)
+        _ => ::sha3::Sha3_512,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use digest::Digest;
@@ -49,5 +63,31 @@ mod tests {
     )]
     fn keccak512_has_not_changed(#[case] data: &[u8], #[case] output: [u8; 64]) {
         assert!(Keccak512::digest(data) == output, "has changed");
+    }
+
+    #[rstest]
+    #[case(
+        b"",
+        hex!("a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a"),
+    )]
+    #[case(
+        b"test",
+        hex!("36f028580bb02cc8272a9a020f4200e346e276ae664e45ee80745574e2f5ab80"),
+    )]
+    fn sha3_256_has_not_changed(#[case] data: &[u8], #[case] output: [u8; 32]) {
+        assert!(Sha3_256::digest(data) == output, "has changed");
+    }
+
+    #[rstest]
+    #[case(
+        b"",
+        hex!("a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26"),
+    )]
+    #[case(
+        b"test",
+        hex!("9ece086e9bac491fac5c1d1046ca11d737b92a2b2ebd93f005d7b710110c0a678288166e7fbe796883a4f2e9b3ca9f484f521d0ce464345cc1aec96779149c14"),
+    )]
+    fn sha3_512_has_not_changed(#[case] data: &[u8], #[case] output: [u8; 64]) {
+        assert!(Sha3_512::digest(data) == output, "has changed");
     }
 }

--- a/crates/digest/src/utils.rs
+++ b/crates/digest/src/utils.rs
@@ -7,6 +7,7 @@ pub trait DigestFinalizer: OutputSizeUser {
     fn digest(bytes: &[u8]) -> Output<Self>;
 }
 
+#[cfg_attr(feature = "zeroize", derive(::zeroize::ZeroizeOnDrop))]
 #[autoimpl(Debug, Clone, Default, PartialEq, Eq)]
 pub struct DigestFn<F> {
     data: Vec<u8>,

--- a/crates/kdf/Cargo.toml
+++ b/crates/kdf/Cargo.toml
@@ -36,6 +36,7 @@ zeroize = ["curve25519-dalek?/zeroize", "ed25519-dalek?/zeroize"]
 
 [dev-dependencies]
 defuse-kdf = { workspace = true, features = ["borsh", "digest", "ed25519", "secp256k1", "hex"] }
+
+defuse-digest = { workspace = true, features = ["sha3"] }
 hex-literal.workspace = true
 rstest.workspace = true
-sha3.workspace = true

--- a/crates/kdf/Cargo.toml
+++ b/crates/kdf/Cargo.toml
@@ -40,3 +40,6 @@ defuse-kdf = { workspace = true, features = ["borsh", "digest", "ed25519", "secp
 defuse-digest = { workspace = true, features = ["sha3"] }
 hex-literal.workspace = true
 rstest.workspace = true
+
+[target.'cfg(near)'.dev-dependencies]
+near-sdk = { workspace = true, features = ["unit-testing"] }

--- a/crates/kdf/mpc/Cargo.toml
+++ b/crates/kdf/mpc/Cargo.toml
@@ -9,11 +9,11 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
+defuse-digest = { workspace = true, features = ["sha3"] }
 defuse-kdf = { workspace = true, features = ["digest"] }
 
 impl-tools.workspace = true
 near-account-id.workspace = true
-sha3.workspace = true
 
 [features]
 default = ["ed25519", "secp256k1"]

--- a/crates/kdf/mpc/Cargo.toml
+++ b/crates/kdf/mpc/Cargo.toml
@@ -24,3 +24,6 @@ secp256k1 = ["defuse-kdf/secp256k1"]
 [dev-dependencies]
 hex-literal.workspace = true
 rstest.workspace = true
+
+[target.'cfg(near)'.dev-dependencies]
+near-sdk = { workspace = true, features = ["unit-testing"] }

--- a/crates/kdf/mpc/src/ckd.rs
+++ b/crates/kdf/mpc/src/ckd.rs
@@ -1,6 +1,6 @@
+use defuse_digest::{Digest as _, sha3::Sha3_256};
 use defuse_kdf::digest::Digest;
 use near_account_id::AccountIdRef;
-use sha3::{Digest as _, Sha3_256};
 
 use crate::derive_from_path;
 

--- a/crates/kdf/mpc/src/lib.rs
+++ b/crates/kdf/mpc/src/lib.rs
@@ -3,10 +3,10 @@ mod tweak;
 
 pub use self::{ckd::*, tweak::*};
 
+use defuse_digest::{Digest as _, sha3::Sha3_256};
 pub use defuse_kdf as kdf;
 use defuse_kdf::digest::Digest;
 use near_account_id::AccountIdRef;
-use sha3::{Digest as _, Sha3_256};
 
 /// See <https://github.com/near/mpc/blob/f07b9145b17e2372be768aa67a2106be9989a7d7/crates/near-mpc-crypto-types/src/kdf.rs#L25-L39>
 fn derive_from_path(

--- a/crates/kdf/mpc/src/tweak/mod.rs
+++ b/crates/kdf/mpc/src/tweak/mod.rs
@@ -5,10 +5,10 @@ mod secp256k1;
 
 use core::marker::PhantomData;
 
+use defuse_digest::{Digest as _, sha3::Sha3_256};
 use defuse_kdf::{CurveArithmetic, Derive, DeriveExt, Schema, digest::Digest};
 use impl_tools::autoimpl;
 use near_account_id::AccountIdRef;
-use sha3::{Digest as _, Sha3_256};
 
 use crate::derive_from_path;
 

--- a/crates/kdf/src/schema/borsh.rs
+++ b/crates/kdf/src/schema/borsh.rs
@@ -77,7 +77,7 @@ const _: () = {
     /// ```rust
     /// use defuse_kdf::{borsh::{Borsh, IoWrapper}, Schema};
     /// # use hex_literal::hex;
-    /// use sha3::{Digest, Sha3_256};
+    /// use defuse_digest::sha3::Sha3_256;
     ///
     /// let schema = Borsh::<IoWrapper<Sha3_256>>::default();
     /// assert_eq!(

--- a/crates/kdf/src/schema/digest.rs
+++ b/crates/kdf/src/schema/digest.rs
@@ -7,7 +7,7 @@ use crate::Schema;
 /// ```rust
 /// use defuse_kdf::{digest::Digest, Schema};
 /// # use hex_literal::hex;
-/// use sha3::Sha3_256;
+/// use defuse_digest::sha3::Sha3_256;
 ///
 /// let schema = Digest::<Sha3_256>::default();
 /// assert_eq!(
@@ -27,7 +27,7 @@ where
     /// ```rust
     /// use defuse_kdf::{digest::Digest, Schema};
     /// # use hex_literal::hex;
-    /// use sha3::{Digest as _, Sha3_256};
+    /// use defuse_digest::{Digest as _, sha3::Sha3_256};
     ///
     /// let schema = Digest::new(Sha3_256::new_with_prefix(b"prefix"));
     /// assert_eq!(

--- a/crates/signatures/nep413/Cargo.toml
+++ b/crates/signatures/nep413/Cargo.toml
@@ -35,3 +35,6 @@ near-api = ["dep:near-api"]
 
 [dev-dependencies]
 serde_json.workspace = true
+
+[target.'cfg(near)'.dev-dependencies]
+near-sdk = { workspace = true, features = ["unit-testing"] }

--- a/crates/signatures/sep53/Cargo.toml
+++ b/crates/signatures/sep53/Cargo.toml
@@ -17,6 +17,11 @@ schemars = { workspace = true, optional = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"], optional = true }
 serde_with = { workspace = true, optional = true }
 
+[features]
+abi = ["defuse-crypto/abi", "dep:schemars", "serde_with?/schemars_0_8"]
+near-contract = ["defuse-crypto/near-contract"]
+serde = ["defuse-crypto/serde", "dep:cfg_eval", "dep:serde", "dep:serde_with"]
+
 [dev-dependencies]
 defuse-sep53 = { path = ".", features = ["near-contract"] }
 
@@ -26,8 +31,3 @@ near-crypto.workspace = true
 near-sdk = { workspace = true, features = ["unit-testing"] }
 rstest.workspace = true
 stellar-strkey.workspace = true
-
-[features]
-abi = ["defuse-crypto/abi", "dep:schemars", "serde_with?/schemars_0_8"]
-near-contract = ["defuse-crypto/near-contract"]
-serde = ["defuse-crypto/serde", "dep:cfg_eval", "dep:serde", "dep:serde_with"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional SHA-3 hashing options, including SHA3-256 and SHA3-512.
  * Introduced optional zeroization support for digest-related types to help clear sensitive data after use.

* **Bug Fixes**
  * Updated key derivation and MPC hashing to use the shared digest implementation, keeping hashing behavior consistent across the product.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->