### PR TITLE
feat(wallet): `w_init()` method for `no-sign` variant

### DIFF
--- a/contracts/wallet/Cargo.toml
+++ b/contracts/wallet/Cargo.toml
@@ -96,7 +96,7 @@ container_build_command = [
   "--abi-features=abi,contract,webauthn-p256",
 ]
 
-[package.metadata.near.reproducible_build.variant.no-auth]
+[package.metadata.near.reproducible_build.variant.no-sign]
 image = "sourcescan/cargo-near:0.21.1-rust-1.96.0"
 image_digest = "sha256:ccb22bb4e677ed022d8b9d1aa1b32f0af52dd0471ef1c32e48dedbf68ee6ee17"
 passed_env = []

--- a/contracts/wallet/src/contract/impl_.rs
+++ b/contracts/wallet/src/contract/impl_.rs
@@ -86,11 +86,46 @@ macro_rules! contract_impl {
                     standard(standard = "wallet-no-sign", version = "1.0.0")
                 ))
             )] {
-                use crate::signature::no_sign::NoSign;
+                use near_sdk::{env, FunctionError};
+
+                use crate::{Error, signature::no_sign::{NoSign, NoPublicKey}};
 
                 impl ContractImpl for Contract {
                     /// Always reject the signature.
                     type SigningStandard = NoSign;
+                }
+
+                #[near]
+                impl Contract {
+                    #[private]
+                    #[payable]
+                    #[init]
+                    /// Initialize a wallet contract on the existing account
+                    /// with authentication by signature disabled and add the
+                    /// current account as an extension.
+                    ///
+                    /// This method is allowed to be called only by the current
+                    /// account itself. It's recommended to call this method
+                    /// in the same receipt right after `UseGlobalContract` action.
+                    ///
+                    /// MUST attach at least 1yN for security reasons.
+                    pub fn w_init() -> Self {
+                        if env::attached_deposit().is_zero() {
+                            // reject FunctionCall access keys
+                            Error::InsufficientDeposit.panic();
+                        }
+
+                        let mut s = crate::State::new(NoPublicKey)
+                            // Add self as the only extension
+                            .extensions([env::current_account_id()]);
+
+                        // Disable signature verification completely,
+                        // so that removing self from extensions would
+                        // result into lockout error.
+                        s.signature_enabled = false;
+
+                        Self(s)
+                    }
                 }
             }
         }

--- a/contracts/wallet/src/contract/impl_.rs
+++ b/contracts/wallet/src/contract/impl_.rs
@@ -120,8 +120,8 @@ macro_rules! contract_impl {
                             .extensions([env::current_account_id()]);
 
                         // Disable signature verification completely,
-                        // so that removing self from extensions would
-                        // result into lockout error.
+                        // so that accidently removing self from extensions
+                        // would result into lockout error.
                         s.signature_enabled = false;
 
                         Self(s)

--- a/contracts/wallet/src/contract/impl_.rs
+++ b/contracts/wallet/src/contract/impl_.rs
@@ -101,8 +101,8 @@ macro_rules! contract_impl {
                     #[payable]
                     #[init]
                     /// Initialize a wallet contract on the existing account
-                    /// with authentication by signature disabled and add the
-                    /// current account as an extension.
+                    /// with authentication by signature disabled and
+                    /// add the current account as an extension.
                     ///
                     /// This method is allowed to be called only by the current
                     /// account itself. It's recommended to call this method

--- a/contracts/wallet/src/contract/mod.rs
+++ b/contracts/wallet/src/contract/mod.rs
@@ -12,7 +12,6 @@ use near_sdk::{AccountId, AccountIdRef, FunctionError, Promise, env, near};
 
 use crate::{Actor, Error, Result, Wallet, WalletEvent, signature::SigningStandard};
 
-// TODO: init on existing (e.g. named) account ids?
 #[near]
 impl Wallet for Contract {
     #[payable]

--- a/contracts/wallet/src/signature/no_sign.rs
+++ b/contracts/wallet/src/signature/no_sign.rs
@@ -34,7 +34,7 @@ impl<M> SigningStandard<M> for NoSign {
     schemars(crate = "::near_sdk::schemars", with = "String")
 )]
 #[near(serializers = [borsh])]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, SerializeDisplay, DeserializeFromStr)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, SerializeDisplay, DeserializeFromStr)]
 #[serde_with(crate = "::near_sdk::serde_with")]
 pub struct NoPublicKey;
 

--- a/crates/testing/utils/src/wasms.rs
+++ b/crates/testing/utils/src/wasms.rs
@@ -52,6 +52,10 @@ pub static ESCROW_SWAP_WASM: LazyLock<Vec<u8>> =
 pub static WALLET_WASM: LazyLock<Vec<u8>> =
     LazyLock::new(|| read_wasm(&ReadWasmMode::BuildArtifact, "defuse-wallet.wasm"));
 
+#[cfg(feature = "wallet")]
+pub static WALLET_NO_SIGN_WASM: LazyLock<Vec<u8>> =
+    LazyLock::new(|| read_wasm(&ReadWasmMode::BuildArtifact, "defuse-wallet.no-sign.wasm"));
+
 #[cfg(feature = "poa")]
 pub static POA_FACTORY_WASM: LazyLock<Vec<u8>> =
     LazyLock::new(|| read_wasm(&ReadWasmMode::BuildArtifact, "defuse-poa-factory.wasm"));

--- a/tests/src/tests/wallet/mod.rs
+++ b/tests/src/tests/wallet/mod.rs
@@ -1,3 +1,5 @@
+mod no_sign;
+
 use std::borrow::Cow;
 
 use defuse_sandbox::{
@@ -253,12 +255,15 @@ impl Env {
 
 #[fixture]
 #[awt]
-async fn env(#[future] root: Near) -> Env {
+async fn env(
+    #[default(WALLET_WASM.clone())] wasm: impl Into<Vec<u8>>,
+    #[future] root: Near,
+) -> Env {
     // wallet.0.test
     let wallet_global_id = root
         .deploy_upgradable_global_contract(
             root.account_id().sub_account("wallet").unwrap(),
-            WALLET_WASM.clone(),
+            wasm,
             NearToken::from_near(1000),
         )
         .await

--- a/tests/src/tests/wallet/no_sign.rs
+++ b/tests/src/tests/wallet/no_sign.rs
@@ -1,0 +1,72 @@
+use defuse_sandbox::kit::{self, Action, Final, UseGlobalContractAction};
+use defuse_test_utils::wasms::WALLET_NO_SIGN_WASM;
+use rstest::rstest;
+
+use super::*;
+
+#[rstest]
+#[awt]
+#[tokio::test]
+async fn test_w_init(
+    #[future]
+    #[with(WALLET_NO_SIGN_WASM.clone())]
+    env: Env,
+) {
+    let user = env
+        .create_subaccount("user", NearToken::from_near(10))
+        .await;
+
+    // initialize wallet contract on existing account
+    user.transaction(user.account_id())
+        .add_action(Action::UseGlobalContract(UseGlobalContractAction {
+            contract_identifier: env.wallet_global_id.clone(),
+        }))
+        .add_action(
+            kit::FunctionCall::new("w_init")
+                .gas(Gas::from_tgas(5))
+                .deposit(NearToken::from_yoctonear(1)),
+        )
+        .wait_until(Final)
+        .await
+        .unwrap()
+        .result()
+        .unwrap();
+
+    let user2 = env
+        .create_subaccount("user2", NearToken::from_near(1))
+        .await;
+
+    // add another account as an extension
+    user.w_execute_extension(
+        user.account_id(),
+        None,
+        &Request::new().ops([WalletOp::AddExtension {
+            account_id: user2.account_id().into(),
+        }]),
+        NearToken::from_yoctonear(1),
+    )
+    .await
+    .unwrap();
+
+    let receiver = env.create_implicit(None).await;
+
+    // send extension request from user2
+    user2
+        .w_execute_extension(
+            user.account_id(),
+            None,
+            &Request::new()
+                .out([NearPromise::new(receiver.account_id()).transfer(NearToken::from_near(5))]),
+            NearToken::from_yoctonear(1),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        env.balance(receiver.account_id())
+            .await
+            .expect("implicit account should be created by incoming transfer")
+            .total,
+        NearToken::from_near(5),
+    );
+}

--- a/tests/src/tests/wallet/no_sign.rs
+++ b/tests/src/tests/wallet/no_sign.rs
@@ -32,6 +32,17 @@ async fn test_w_init(
         .result()
         .unwrap();
 
+    user.w_execute_extension(
+        user.account_id(),
+        None,
+        &Request::new().ops([WalletOp::RemoveExtension {
+            account_id: user.account_id().into(),
+        }]),
+        NearToken::from_yoctonear(1),
+    )
+    .await
+    .expect_err("cannot accidentally delete itself from extension");
+
     let user2 = env
         .create_subaccount("user2", NearToken::from_near(1))
         .await;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for initializing the wallet in a no-sign mode with a required deposit.
  * Added a separate wallet build artifact for no-sign deployments.
* **Bug Fixes**
  * Improved setup for wallets created on existing accounts.
* **Tests**
  * Added coverage for no-sign wallet initialization and extension-based transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->