### PR TITLE
fix!(wallet): remove idempotency from ops

### DIFF
--- a/contracts/wallet/src/contract/mod.rs
+++ b/contracts/wallet/src/contract/mod.rs
@@ -120,17 +120,14 @@ impl Contract {
     fn execute_op(&mut self, op: WalletOp, actor: Actor<'_>) -> Result<()> {
         match op {
             WalletOp::SetSignatureMode { enable } => self.set_signature_mode(enable, actor),
-            WalletOp::AddExtension { account_id } => {
-                self.add_extension(&account_id, actor);
-                Ok(())
-            }
+            WalletOp::AddExtension { account_id } => self.add_extension(account_id, actor),
             WalletOp::RemoveExtension { account_id } => self.remove_extension(&account_id, actor),
         }
     }
 
     fn set_signature_mode(&mut self, enable: bool, actor: Actor<'_>) -> Result<()> {
         if self.signature_enabled == enable {
-            return Ok(());
+            return Err(Error::ThisSignatureModeAlreadySet);
         }
         self.signature_enabled = enable;
         self.check_lockout()?;
@@ -144,9 +141,9 @@ impl Contract {
         Ok(())
     }
 
-    fn add_extension(&mut self, account_id: &AccountIdRef, actor: Actor<'_>) {
-        if !self.extensions.insert(account_id.to_owned()) {
-            return;
+    fn add_extension(&mut self, account_id: AccountId, actor: Actor<'_>) -> Result<()> {
+        if !self.extensions.insert(account_id.clone()) {
+            return Err(Error::ExtensionEnabled(account_id));
         }
 
         WalletEvent::ExtensionAdded {
@@ -154,11 +151,13 @@ impl Contract {
             by: actor,
         }
         .emit();
+
+        Ok(())
     }
 
     fn remove_extension(&mut self, account_id: &AccountIdRef, actor: Actor<'_>) -> Result<()> {
         if !self.extensions.remove(account_id) {
-            return Ok(());
+            return Err(Error::ExtensionNotEnabled(account_id.to_owned()));
         }
         self.check_lockout()?;
 

--- a/crates/wallet/core/src/request/ops.rs
+++ b/crates/wallet/core/src/request/ops.rs
@@ -19,20 +19,16 @@ use near_account_id::AccountId;
 pub enum WalletOp {
     /// Enable or disable authentication by signature.
     ///
-    /// This operation is idempotent, i.e. no error will be raised if
-    /// signature mode is already in this state.
+    /// If signature mode is already in specified state, the contract MUST panic.
     SetSignatureMode { enable: bool } = 0,
 
     /// Add an extension with given `AccountId`.
     ///
-    /// This operation is idempotent, i.e. no error will be raised if
-    /// given extension is already enabled.
+    /// If this extension is already enabled, the contract MUST panic.
     AddExtension { account_id: AccountId } = 1,
 
     /// Remove an extension with given `AccountId`.
     ///
-    /// This operation is idempotent, i.e. no error will be raised if
-    /// given extension is not currently enabled.
+    /// If this extension is not currently enabled, the contract MUST panic.
     RemoveExtension { account_id: AccountId } = 2,
-    // TODO: Require* ops
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Signature mode changes now fail if the requested mode is already active, instead of being treated as a no-op.
  * Adding an extension now returns an error if it is already enabled.
  * Removing an extension now returns an error if it is not currently enabled.
  * Extension removal now performs an additional safety check that may block invalid wallet states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->