### PR TITLE
chore(wallet): use relayer in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1800,6 +1800,7 @@ dependencies = [
  "defuse-randomness",
  "defuse-sandbox",
  "defuse-test-utils",
+ "defuse-wallet-relayer",
  "derive_more",
  "futures",
  "impl-tools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1962,6 +1962,7 @@ dependencies = [
  "defuse-digest",
  "defuse-wallet-client",
  "defuse-wallet-core",
+ "defuse-wallet-relayer",
  "defuse-wallet-sdk",
  "ed25519-dalek",
  "futures",

--- a/crates/wallet/relayer/Cargo.toml
+++ b/crates/wallet/relayer/Cargo.toml
@@ -17,11 +17,22 @@ near-kit.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
-tracing.workspace = true
+
+tracing = { workspace = true, optional = true }
+
+[features]
+tracing = [
+  "defuse-wallet-core/borsh",
+  "defuse-wallet-core/digest",
+  "dep:tracing",
+]
 
 [dev-dependencies]
+defuse-wallet-relayer = { path = ".", features = ["tracing"] }
+
 defuse-digest = { workspace = true, features = ["sha2"] }
 defuse-wallet-sdk.workspace = true
+
 ed25519-dalek = { workspace = true, features = ["rand_core"] }
 hex.workspace = true
 near-kit = { workspace = true, features = ["sandbox"] }

--- a/crates/wallet/relayer/examples/relay.rs
+++ b/crates/wallet/relayer/examples/relay.rs
@@ -3,7 +3,7 @@
 use std::{env, fs, iter, path::Path, sync::LazyLock};
 
 use defuse_digest::{Digest, sha2::Sha256};
-use defuse_wallet_relayer::{RelayRequest, Relayer};
+use defuse_wallet_relayer::{WalletRelayRequest, WalletRelayer};
 use defuse_wallet_sdk::{NearToken, Request, WalletSigner};
 use ed25519_dalek::ed25519::signature::rand_core::OsRng;
 use futures::{StreamExt, TryFutureExt, TryStreamExt, stream};
@@ -39,7 +39,7 @@ async fn main() {
         GlobalContractId::CodeHash(Sha256::digest(&*WALLET_WASM).into())
     };
 
-    let relayer = Relayer::new(near.clone());
+    let relayer = WalletRelayer::new(near.clone());
 
     let mut wallet = WalletSigner::new(
         global_contract_id,
@@ -56,7 +56,7 @@ async fn main() {
             let (msg, proof) = wallet.sign(Request::new()).unwrap();
             relayer
                 .w_execute_signed(
-                    RelayRequest {
+                    WalletRelayRequest {
                         state_init: Some(wallet.deterministic_state_init()),
                         msg,
                         proof,
@@ -70,7 +70,7 @@ async fn main() {
         })
         .take(txs_count),
     )
-    .buffer_unordered(1000);
+    .buffer_unordered(500);
 
     let started_at = tokio::time::Instant::now();
     txs.try_collect::<()>().await.unwrap();

--- a/crates/wallet/relayer/src/lib.rs
+++ b/crates/wallet/relayer/src/lib.rs
@@ -1,3 +1,7 @@
+mod request;
+
+pub use self::request::*;
+
 use std::{borrow::Cow, time::Duration};
 
 use defuse_wallet_client::{WExecuteSignedArgs, Wallet};
@@ -8,29 +12,17 @@ pub use near_kit;
 
 use near_kit::{
     CryptoHash, ExecutedOptimistic, FinalExecutionOutcome, Gas, InvalidTxError, Near, NearToken,
-    StateInit,
 };
-use serde::{Deserialize, Serialize};
 use thiserror::Error as ThisError;
 use tracing::{field, instrument};
 
 #[derive(Debug)]
-pub struct Relayer {
+pub struct WalletRelayer {
     client: Near,
     gas: Gas,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct RelayRequest {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub state_init: Option<StateInit>, // TODO
-    pub msg: RequestMessage,
-    pub proof: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub gas: Option<Gas>,
-}
-
-impl Relayer {
+impl WalletRelayer {
     #[allow(clippy::doc_markdown)]
     // TODO: remove once https://github.com/near/nearcore/pull/15461 is on mainnet
     /// Only assist with at most 1yN: it's enough for a single permissioned
@@ -69,7 +61,7 @@ impl Relayer {
     ))]
     pub async fn w_execute_signed(
         &self,
-        request: RelayRequest,
+        request: WalletRelayRequest,
         deposit: NearToken,
         max_gas: impl Into<Option<Gas>>,
     ) -> Result<FinalExecutionOutcome> {

--- a/crates/wallet/relayer/src/lib.rs
+++ b/crates/wallet/relayer/src/lib.rs
@@ -10,10 +10,9 @@ pub use defuse_wallet_core as wallet;
 use defuse_wallet_core::{RequestMessage, Timestamp};
 pub use near_kit;
 
-use near_kit::{
-    CryptoHash, ExecutedOptimistic, FinalExecutionOutcome, Gas, InvalidTxError, Near, NearToken,
-};
+use near_kit::{ExecutedOptimistic, FinalExecutionOutcome, Gas, InvalidTxError, Near, NearToken};
 use thiserror::Error as ThisError;
+#[cfg(feature = "tracing")]
 use tracing::{field, instrument};
 
 #[derive(Debug)]
@@ -54,11 +53,14 @@ impl WalletRelayer {
     /// Relay signed request with optional attached deposit.
     /// If no additional deposit is needed then pass `NearToken::ZERO`.
     // TODO: return request hash?
-    #[instrument(skip_all, fields(
-        signer_id = %request.msg.signer_id,
-        request.hash = %CryptoHash::from_bytes(request.msg.hash()),
-        deposit = Some(deposit).filter(|d| !d.is_zero()).map(field::display),
-    ))]
+    #[cfg_attr(
+        feature = "tracing",
+        instrument(skip_all, fields(
+            signer_id = %request.msg.signer_id,
+            request.hash = %near_kit::CryptoHash::from_bytes(request.msg.hash()),
+            deposit = Some(deposit).filter(|d| !d.is_zero()).map(field::display),
+        ))
+    )]
     pub async fn w_execute_signed(
         &self,
         request: WalletRelayRequest,

--- a/crates/wallet/relayer/src/request.rs
+++ b/crates/wallet/relayer/src/request.rs
@@ -1,0 +1,40 @@
+use defuse_wallet_core::RequestMessage;
+use near_kit::{Gas, StateInit};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WalletRelayRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_init: Option<StateInit>, // TODO
+    pub msg: RequestMessage,
+    pub proof: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gas: Option<Gas>,
+}
+
+impl WalletRelayRequest {
+    #[must_use]
+    #[inline]
+    pub fn new(msg: RequestMessage, proof: impl Into<String>) -> Self {
+        Self {
+            state_init: None,
+            msg,
+            proof: proof.into(),
+            gas: None,
+        }
+    }
+
+    #[must_use]
+    #[inline]
+    pub fn state_init(mut self, state_init: impl Into<StateInit>) -> Self {
+        self.state_init = Some(state_init.into());
+        self
+    }
+
+    #[must_use]
+    #[inline]
+    pub const fn gas(mut self, gas: Gas) -> Self {
+        self.gas = Some(gas);
+        self
+    }
+}

--- a/crates/wallet/sdk/Cargo.toml
+++ b/crates/wallet/sdk/Cargo.toml
@@ -16,7 +16,7 @@ impl-tools.workspace = true
 near-global-contracts = { workspace = true, features = ["borsh"] }
 rand.workspace = true
 
-defuse-crypto = { workspace = true, optional = true }
+defuse-crypto = { workspace = true, features = ["parse", "borsh"], optional = true }
 ed25519-dalek = { workspace = true, optional = true }
 
 [features]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -30,6 +30,8 @@ serde_json.workspace = true
 strum.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 
+defuse-wallet-relayer = { workspace = true, optional = true }
+
 [features]
 default = [
   "defuse",
@@ -60,6 +62,11 @@ escrow-swap = [
 imt = ["defuse", "defuse-sandbox/imt"]
 outlayer = ["defuse-sandbox/outlayer", "defuse-test-utils/outlayer"]
 poa = ["defuse-sandbox/poa", "defuse-test-utils/poa"]
-wallet = ["defuse-sandbox/wallet", "defuse-test-utils/wallet", "deployer"]
+wallet = [
+  "defuse-sandbox/wallet",
+  "defuse-test-utils/wallet",
+  "dep:defuse-wallet-relayer",
+  "deployer",
+]
 
 long = []

--- a/tests/src/tests/wallet/mod.rs
+++ b/tests/src/tests/wallet/mod.rs
@@ -13,11 +13,12 @@ use defuse_sandbox::{
         },
     },
     global_contract::GlobalContract,
-    kit::{Gas, GlobalContractId, Near, NearToken, StateInit, StateInitV1},
+    kit::{Finality::Optimistic, Gas, GlobalContractId, Near, NearToken, StateInit, StateInitV1},
     root,
 };
 use defuse_test_utils::wasms::WALLET_WASM;
-use futures::{TryStreamExt, stream::FuturesUnordered};
+use defuse_wallet_relayer::{WalletRelayRequest, WalletRelayer};
+use futures::future::join_all;
 use impl_tools::autoimpl;
 use rstest::{fixture, rstest};
 
@@ -48,27 +49,34 @@ async fn test_signed(#[future] env: Env) {
         )
         .unwrap();
 
-    env.w_execute_signed(
-        wallet.account_id(),
-        Some(wallet.deterministic_state_init()),
-        &msg,
-        &proof,
-        NearToken::from_near(1),
-    )
-    .await
-    .unwrap();
+    let request =
+        WalletRelayRequest::new(msg.clone(), &proof).state_init(wallet.deterministic_state_init());
 
-    env.w_execute_signed(
-        wallet.account_id(),
-        Some(wallet.deterministic_state_init()),
-        &msg,
-        &proof,
-        NearToken::from_near(1),
-    )
-    .await
-    .expect_err("nonce should be already used");
+    assert!(
+        env.relayer
+            .w_execute_signed(request.clone(), NearToken::from_near(1), None)
+            .await
+            .unwrap()
+            .is_success(),
+    );
 
-    assert!(env.account(wallet.account_id()).await.unwrap().amount >= NearToken::from_near(1));
+    assert!(
+        env.relayer
+            .w_execute_signed(request.clone(), NearToken::from_near(1), None)
+            .await
+            .unwrap()
+            .is_failure(),
+        "nonce should be already used"
+    );
+
+    assert!(
+        env.account(wallet.account_id())
+            .finality(Optimistic)
+            .await
+            .unwrap()
+            .amount
+            >= NearToken::from_near(1)
+    );
 }
 
 #[rstest]
@@ -122,28 +130,38 @@ async fn test_rotate(#[future] env: Env) {
         )
         .unwrap();
 
-    env.w_execute_signed(
-        old_wallet.account_id(),
-        old_wallet.deterministic_state_init(),
-        &msg,
-        proof,
-        NearToken::from_yoctonear(1),
-    )
-    .await
-    .unwrap();
+    assert!(
+        env.relayer
+            .w_execute_signed(
+                WalletRelayRequest::new(msg, proof)
+                    .state_init(old_wallet.deterministic_state_init()),
+                NearToken::from_yoctonear(1),
+                None,
+            )
+            .await
+            .unwrap()
+            .is_success()
+    );
 
     assert!(
         !env.contract::<Wallet>(old_wallet.account_id())
             .w_is_signature_allowed()
+            .finality(Optimistic)
             .await
             .unwrap()
     );
 
     {
         let (msg, proof) = old_wallet.sign(Request::default()).unwrap();
-        env.w_execute_signed(old_wallet.account_id(), None, &msg, proof, NearToken::ZERO)
-            .await
-            .expect_err("signature should be disabled");
+
+        assert!(
+            env.relayer
+                .w_execute_signed(WalletRelayRequest::new(msg, proof), NearToken::ZERO, None)
+                .await
+                .unwrap()
+                .is_failure(),
+            "signature should be disabled",
+        );
     }
 
     let (msg, proof) = new_wallet
@@ -159,9 +177,13 @@ async fn test_rotate(#[future] env: Env) {
         )
         .unwrap();
 
-    env.w_execute_signed(new_wallet.account_id(), None, &msg, proof, NearToken::ZERO)
-        .await
-        .unwrap();
+    assert!(
+        env.relayer
+            .w_execute_signed(WalletRelayRequest::new(msg, proof), NearToken::ZERO, None)
+            .await
+            .unwrap()
+            .is_success()
+    );
 }
 
 #[rstest]
@@ -199,7 +221,14 @@ async fn test_extension(#[future] env: Env) {
         .await
         .unwrap();
 
-    assert!(env.account(receiver.account_id()).await.unwrap().amount >= NearToken::from_near(1));
+    assert!(
+        env.account(receiver.account_id())
+            .finality(Optimistic)
+            .await
+            .unwrap()
+            .amount
+            >= NearToken::from_near(1)
+    );
 }
 
 #[rstest]
@@ -220,26 +249,30 @@ async fn test_no_storage_staking(#[future] env: Env) {
         .result()
         .unwrap();
 
-    (0..wallet.nonces.timeout().as_secs() * 2)
-        .map(|_n| wallet.sign(Request::new()).unwrap())
-        .map(|(msg, proof)| {
-            let env = &env;
-            let wallet_id = wallet_id.clone();
-            async move {
-                env.w_execute_signed(wallet_id, None, &msg, proof, NearToken::ZERO)
-                    .await
-                    .map(|_| ())
-            }
-        })
-        .collect::<FuturesUnordered<_>>()
-        .try_collect::<()>()
-        .await
-        .unwrap();
+    join_all(
+        (0..wallet.nonces.timeout().as_secs() * 2)
+            .map(|_n| {
+                let (msg, proof) = wallet.sign(Request::new()).unwrap();
+                WalletRelayRequest::new(msg, proof)
+            })
+            .map(|req| async {
+                assert!(
+                    env.relayer
+                        .w_execute_signed(req, NearToken::ZERO, None)
+                        .await
+                        .unwrap()
+                        .is_success()
+                );
+            }),
+    )
+    .await;
 }
 
 #[autoimpl(Deref using self.root)]
 struct Env {
     pub wallet_global_id: GlobalContractId,
+
+    pub relayer: WalletRelayer,
 
     root: Near,
 }
@@ -271,6 +304,7 @@ async fn env(
 
     Env {
         wallet_global_id,
+        relayer: WalletRelayer::new(root.clone()),
         root,
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wallet signing flows now go through an updated relayer interface, enabling signed requests to include proof, optional setup data, and gas settings in a single package.

* **Bug Fixes**
  * Improved wallet execution handling for signature replay and wallet rotation scenarios.
  * Reduced the number of concurrent relay operations to make large batches more stable.

* **Documentation**
  * Updated internal example usage to match the latest wallet relayer API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->