### PR TITLE
feat(ckd): make `.decrypt()` public

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5662,9 +5662,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spki"

--- a/crates/ckd/src/lib.rs
+++ b/crates/ckd/src/lib.rs
@@ -112,6 +112,7 @@ impl AppPrivateKey {
     /// **NOTE**: Returned secret's entropy is not distrubuted uniformly, so
     /// it shouldn't be used as-is. Instead, use HKDF to derive a strong
     /// uniformly-distributed key.
+    #[inline]
     pub fn decrypt_verify(
         &self,
         mpc_public_key: G2Affine,
@@ -148,8 +149,19 @@ impl AppPrivateKey {
     /// Decrypt a secret from given response **without** [verifying](Self::decrypt_verify)
     /// that it was derived from a given MPC public key for a given predecessor and path.
     ///
+    /// **NOTE**: Returned secret's entropy is not distrubuted uniformly, so
+    /// it shouldn't be used as-is. Instead, use HKDF to derive a strong
+    /// uniformly-distributed key.
+    ///
     /// See <https://github.com/near/mpc/blob/f7a959d2bfd723e92c3bd71a5b60e03d972a2ddb/crates/ckd-example-cli/src/ckd.rs#L128-L129>
-    pub fn decrypt(&self, resp: CkdResponse) -> Option<G1Affine> {
+    #[inline]
+    pub fn decrypt_unchecked(&self, resp: CkdResponse) -> Option<Secret> {
+        let secret = self.decrypt(resp)?;
+
+        Some(secret.to_compressed())
+    }
+
+    fn decrypt(&self, resp: CkdResponse) -> Option<G1Affine> {
         if !resp.is_valid() {
             return None;
         }
@@ -192,6 +204,7 @@ impl AppPrivateKey {
     /// Check that `e(sig, g2) = e(hash_point, mpc_public_key)`
     ///
     /// See <https://github.com/near/mpc/blob/f7a959d2bfd723e92c3bd71a5b60e03d972a2ddb/crates/ckd-example-cli/src/ckd.rs#L100-L115>
+    #[must_use = "check whether verification succeeded"]
     fn verify(mpc_public_key: G2Affine, app_id: &[u8; 32], signature: G1Affine) -> bool {
         if !is_valid_g1(&signature) || !is_valid_g2(&mpc_public_key) {
             return false;
@@ -240,6 +253,7 @@ impl AppPublicKeyPV {
     /// Check that `e(app_pk1, g2) = e(g1, app_pk2)`
     ///
     /// See <https://github.com/near/mpc/blob/f7a959d2bfd723e92c3bd71a5b60e03d972a2ddb/crates/contract/src/primitives/ckd.rs#L34-L54>
+    #[must_use = "check whether validation passed"]
     pub fn is_valid(&self) -> bool {
         if !is_valid_g1(&self.pk1) || !is_valid_g2(&self.pk2) {
             return false;
@@ -278,6 +292,8 @@ impl AppPublicKeyPV {
 
     /// Shorthand for [`.verify_app_id()`](AppPublicKeyPV::verify_app_id) with `app_id`
     /// derived from `predecessor_id` and `path`
+    #[must_use = "check whether verification passed"]
+    #[inline]
     pub fn verify(
         &self,
         mpc_public_key: G2Affine,
@@ -293,6 +309,7 @@ impl AppPublicKeyPV {
     /// Verify that `e(big_c, g2) = e(big_y, app_pk2) * e(hash_point, public_key)`
     ///
     /// See <https://github.com/near/mpc/blob/f7a959d2bfd723e92c3bd71a5b60e03d972a2ddb/crates/contract/src/primitives/ckd.rs#L56-L83>
+    #[must_use = "check whether verification passed"]
     pub fn verify_app_id(
         &self,
         mpc_public_key: G2Affine,
@@ -350,6 +367,7 @@ impl CkdResponse {
     /// Check if points in the response are valid.
     ///
     /// See [`AppPublicKeyPV::verify`] for full public verification.
+    #[must_use = "check whether validation passed"]
     #[inline]
     pub fn is_valid(&self) -> bool {
         // See <https://github.com/near/mpc/blob/f7a959d2bfd723e92c3bd71a5b60e03d972a2ddb/crates/contract/src/primitives/ckd.rs#L69-L71>

--- a/crates/ckd/src/lib.rs
+++ b/crates/ckd/src/lib.rs
@@ -112,6 +112,7 @@ impl AppPrivateKey {
     /// **NOTE**: Returned secret's entropy is not distrubuted uniformly, so
     /// it shouldn't be used as-is. Instead, use HKDF to derive a strong
     /// uniformly-distributed key.
+    #[must_use = "use HKDF to derive a strong uniformly-distributed key"]
     #[inline]
     pub fn decrypt_verify(
         &self,
@@ -131,6 +132,7 @@ impl AppPrivateKey {
     /// **NOTE**: Returned secret's entropy is not distrubuted uniformly, so
     /// it shouldn't be used as-is. Instead, use HKDF to derive a strong
     /// uniformly-distributed key.
+    #[must_use = "use HKDF to derive a strong uniformly-distributed key"]
     pub fn decrypt_verify_app_id(
         &self,
         mpc_public_key: G2Affine,
@@ -154,6 +156,7 @@ impl AppPrivateKey {
     /// uniformly-distributed key.
     ///
     /// See <https://github.com/near/mpc/blob/f7a959d2bfd723e92c3bd71a5b60e03d972a2ddb/crates/ckd-example-cli/src/ckd.rs#L128-L129>
+    #[must_use = "use HKDF to derive a strong uniformly-distributed key"]
     #[inline]
     pub fn decrypt_unchecked(&self, resp: CkdResponse) -> Option<Secret> {
         let secret = self.decrypt(resp)?;
@@ -161,6 +164,7 @@ impl AppPrivateKey {
         Some(secret.to_compressed())
     }
 
+    #[must_use = "use decrypted secret"]
     fn decrypt(&self, resp: CkdResponse) -> Option<G1Affine> {
         if !resp.is_valid() {
             return None;

--- a/crates/ckd/src/lib.rs
+++ b/crates/ckd/src/lib.rs
@@ -149,8 +149,16 @@ impl AppPrivateKey {
         Some(secret.to_compressed())
     }
 
+    /// Decrypt the secret without verifying that it was derived from a given
+    /// MPC public key for a given predecessor and path.
+    ///
+    /// **NOTE**: unlike [`Self::decrypt_verify`] and
+    /// [`Self::decrypt_verify_app_id`], this does not check [`CkdResponse`]
+    /// validity or verify the result against an MPC public key, so callers
+    /// must perform that verification themselves before trusting the output.
+    ///
     /// See <https://github.com/near/mpc/blob/f7a959d2bfd723e92c3bd71a5b60e03d972a2ddb/crates/ckd-example-cli/src/ckd.rs#L128-L129>
-    fn decrypt(&self, resp: CkdResponse) -> G1Affine {
+    pub fn decrypt(&self, resp: CkdResponse) -> G1Affine {
         cfg_select! {
             near => {
                 let uncompressed: [u8; G1Affine::uncompressed_size()] =

--- a/crates/ckd/src/lib.rs
+++ b/crates/ckd/src/lib.rs
@@ -125,7 +125,7 @@ impl AppPrivateKey {
     }
 
     /// Decrypt the secret and verify that it was derived from given MPC
-    /// public key for given predecessor and path.
+    /// public key for given `app_id`.
     ///
     /// **NOTE**: Returned secret's entropy is not distrubuted uniformly, so
     /// it shouldn't be used as-is. Instead, use HKDF to derive a strong
@@ -136,11 +136,7 @@ impl AppPrivateKey {
         app_id: &[u8; 32],
         resp: CkdResponse,
     ) -> Option<Secret> {
-        if !resp.is_valid() {
-            return None;
-        }
-
-        let secret = self.decrypt(resp);
+        let secret = self.decrypt(resp)?;
 
         if !Self::verify(mpc_public_key, app_id, secret) {
             return None;
@@ -149,18 +145,17 @@ impl AppPrivateKey {
         Some(secret.to_compressed())
     }
 
-    /// Decrypt the secret without verifying that it was derived from a given
-    /// MPC public key for a given predecessor and path.
-    ///
-    /// **NOTE**: unlike [`Self::decrypt_verify`] and
-    /// [`Self::decrypt_verify_app_id`], this does not check [`CkdResponse`]
-    /// validity or verify the result against an MPC public key, so callers
-    /// must perform that verification themselves before trusting the output.
+    /// Decrypt a secret from given response **without** [verifying](Self::decrypt_verify)
+    /// that it was derived from a given MPC public key for a given predecessor and path.
     ///
     /// See <https://github.com/near/mpc/blob/f7a959d2bfd723e92c3bd71a5b60e03d972a2ddb/crates/ckd-example-cli/src/ckd.rs#L128-L129>
-    pub fn decrypt(&self, resp: CkdResponse) -> G1Affine {
-        cfg_select! {
-            near => {
+    pub fn decrypt(&self, resp: CkdResponse) -> Option<G1Affine> {
+        if !resp.is_valid() {
+            return None;
+        }
+
+        let secret = cfg_select! {
+            near => {{
                 let uncompressed: [u8; G1Affine::uncompressed_size()] =
                     ::near_sdk::env::bls12381_p1_sum(
                         [
@@ -183,13 +178,15 @@ impl AppPrivateKey {
 
                 G1Affine::from_uncompressed_unchecked(&uncompressed)
                     .expect("uncompressed G1 affine: failed to deserialize")
-            }
-            _ => {
+            }}
+            _ => {{
                 use pairing::group::Curve;
 
                 (resp.big_c - resp.big_y * self.private_key).to_affine()
-            }
-        }
+            }}
+        };
+
+        Some(secret)
     }
 
     /// Check that `e(sig, g2) = e(hash_point, mpc_public_key)`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Exposed private-key decryption as a public API, now returning `Option` to safely handle invalid responses.
- **Bug Fixes**
  - Improved invalid-response handling by adding explicit validity checking and short-circuiting on failure.
- **Documentation**
  - Updated decryption-related docs to clarify verification expectations and how inputs are interpreted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->