### PR TITLE
fix(wallet/sdk): reset `initialized` state when switching to other chain

### DIFF
--- a/crates/wallet/sdk/examples/mpc_sign.rs
+++ b/crates/wallet/sdk/examples/mpc_sign.rs
@@ -22,7 +22,7 @@ const PATH: &str = "derivation path";
 async fn main() {
     let near = Near::from_env().unwrap();
 
-    // 1) Generate a keypair and Build a wallet
+    // 0. Generate a keypair and Build a wallet
     let signer = ed25519_dalek::SigningKey::generate(&mut UnwrapErr(SysRng));
     let wallet = Wallet::<WalletEd25519>::new(
         WALLET_GLOBAL_CONTRACT_ID.to_owned(),
@@ -33,17 +33,17 @@ async fn main() {
 
     println!("wallet account ID: {}", wallet.account_id());
 
-    // 1) Prepare MPC signer
+    // 1. Prepare MPC signer
     let mpc_signer = wallet.mpc_signer::<Secp256k1>(0).await.unwrap();
 
-    // 2) Derive MPC public key
+    // 2. Derive MPC public key
     let derived_pk = mpc_signer.derive_public_key(PATH);
     println!(
         "derived public key: {}",
         Secp256k1UncompressedPublicKey::from(derived_pk)
     );
 
-    // 3) Sign via MPC
+    // 3. Sign via MPC
     let prehash = hex!("0128fdba02691843069aba70c0523b9c43f4b0de4e34962462b0525490780a53");
     let started_at = tokio::time::Instant::now();
     let (signature, recovery_id) = mpc_signer
@@ -57,7 +57,7 @@ async fn main() {
         started_at.elapsed(),
     );
 
-    // 4) Verify the signature
+    // 4. Verify the signature
     assert_eq!(
         Secp256k1::recover(&prehash, &signature, recovery_id),
         Some(derived_pk)

--- a/crates/wallet/sdk/src/lib.rs
+++ b/crates/wallet/sdk/src/lib.rs
@@ -212,7 +212,10 @@ where
     pub fn with_chain_id(mut self, chain_id: impl Into<ChainId>) -> Self {
         let old_chain_id = mem::replace(&mut self.chain_id, chain_id.into());
         if self.chain_id != old_chain_id {
-            // contracts on different chains keep track of their own nonces
+            // same wallet account ID on different chain might not have been
+            // initialized yet
+            self.initialized = false;
+            // same wallet instances on different chains keep track of their own nonces
             self.reseed_nonces();
 
             #[cfg(feature = "mpc")]
@@ -227,7 +230,7 @@ where
 
     /// Configure Near client for this wallet.
     ///
-    /// This also resets [`chain_id`](Self::with_chain_id) with client's one.
+    /// This also [resets chain ID](Self::with_chain_id) with client's one.
     #[cfg(feature = "near-kit")]
     #[must_use]
     #[inline]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified MPC signing example instructions, including key setup, signing, and signature verification steps.
  * Improved wallet documentation for chain initialization, nonce tracking, and client configuration.
  * No functional or API changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->