### PR TITLE
chore: autoimpl `RecoverableDeriveSigner`

### DIFF
--- a/crates/kdf/src/schema/mod.rs
+++ b/crates/kdf/src/schema/mod.rs
@@ -41,7 +41,7 @@ pub trait Schema<P> {
     where
         Self: Sized,
     {
-        Derive(self, with)
+        Derive::new(self, with)
     }
 }
 
@@ -67,7 +67,18 @@ impl<T> Schema<T> for Identity {
 /// Derive adaptor for [`Schema`] and [`crate::DeriveSigner`].
 /// See [`.derive()`](Derive::derive).
 #[derive(Debug, Clone, Copy, Default)]
-pub struct Derive<S, D>(pub(crate) S, pub(crate) D);
+pub struct Derive<S, D> {
+    pub(crate) outer: S,
+    pub(crate) inner: D,
+}
+
+impl<S, D> Derive<S, D> {
+    #[must_use]
+    #[inline]
+    pub const fn new(outer: S, inner: D) -> Self {
+        Self { outer, inner }
+    }
+}
 
 impl<P, S, D> Schema<P> for Derive<S, D>
 where
@@ -78,7 +89,7 @@ where
 
     #[inline]
     fn derive(&self, path: P) -> Self::Output {
-        self.0.derive(self.1.derive(path))
+        self.outer.derive(self.inner.derive(path))
     }
 }
 

--- a/crates/kdf/src/schema/mod.rs
+++ b/crates/kdf/src/schema/mod.rs
@@ -24,7 +24,7 @@ pub trait Schema<P> {
     /// Derive output for given `path`.
     fn derive(&self, path: P) -> Self::Output;
 
-    /// Derive with given [schema](Schema).
+    /// Derive with given inner sub-[schema](Schema).
     ///
     /// ```rust
     /// use defuse_kdf::{Schema, SchemaFn};
@@ -37,11 +37,11 @@ pub trait Schema<P> {
     /// assert_eq!(schema_ab.derive(3), 7);
     /// ```
     #[inline]
-    fn derive_with<D>(self, with: D) -> Derive<Self, D>
+    fn derive_with<D>(self, inner: D) -> Derive<Self, D>
     where
         Self: Sized,
     {
-        Derive::new(self, with)
+        Derive::new(self, inner)
     }
 }
 

--- a/crates/kdf/src/signer.rs
+++ b/crates/kdf/src/signer.rs
@@ -56,13 +56,13 @@ pub trait DeriveSigner<C: Curve, P>: Sync {
         self.schema().derive(path)
     }
 
-    /// Derive a signer with sub-[schema](Schema).
+    /// Derive a signer with inner sub-[schema](Schema).
     #[inline]
-    fn derive_with<D>(self, with: D) -> Derive<Self, D>
+    fn derive_with<D>(self, inner: D) -> Derive<Self, D>
     where
         Self: Sized,
     {
-        Derive::new(self, with)
+        Derive::new(self, inner)
     }
 
     /// Derive a signer with a given value for [current](Self::schema) schema,

--- a/crates/kdf/src/signer.rs
+++ b/crates/kdf/src/signer.rs
@@ -56,6 +56,7 @@ pub trait DeriveSigner<C: Curve, P>: Sync {
         self.schema().derive(path)
     }
 
+    /// Derive a signer with sub-[schema](Schema).
     #[inline]
     fn derive_with<D>(self, with: D) -> Derive<Self, D>
     where
@@ -64,6 +65,9 @@ pub trait DeriveSigner<C: Curve, P>: Sync {
         Derive(self, with)
     }
 
+    /// Derive a signer with a given value for [current](Self::schema) schema,
+    /// so that returned signer implements [`Signer`] and doesn't take any
+    /// derivation path.
     #[inline]
     fn derive(self, value: P) -> Derive<Self, Value<P>>
     where
@@ -76,6 +80,7 @@ pub trait DeriveSigner<C: Curve, P>: Sync {
 /// A [signer](DeriveSigner) that can recoverably sign messages by
 /// **internally** deriving signing keys.
 #[trait_variant::make(Send)]
+#[autoimpl(for<T: trait + ?Sized> &T, &mut T, Box<T>, Arc<T>)]
 pub trait RecoverableDeriveSigner<C: RecoverableCurve, P>: DeriveSigner<C, P> {
     /// Recoveryably [sign](DeriveSigner::derive_sign) given message with a
     /// secret key **internally** derived for given `path` according to

--- a/crates/kdf/src/signer.rs
+++ b/crates/kdf/src/signer.rs
@@ -62,7 +62,7 @@ pub trait DeriveSigner<C: Curve, P>: Sync {
     where
         Self: Sized,
     {
-        Derive(self, with)
+        Derive::new(self, with)
     }
 
     /// Derive a signer with a given value for [current](Self::schema) schema,
@@ -118,14 +118,14 @@ where
 
     #[inline]
     fn schema(&self) -> Self::Schema<'_> {
-        self.0.schema().derive_with(&self.1)
+        self.outer.schema().derive_with(&self.inner)
     }
 
     async fn derive_sign(&self, path: P, msg: &[u8]) -> Result<C::Signature, Self::Error>
     where
         P: Send,
     {
-        self.0.derive_sign(self.1.derive(path), msg).await
+        self.outer.derive_sign(self.inner.derive(path), msg).await
     }
 }
 
@@ -143,8 +143,8 @@ where
     where
         P: Send,
     {
-        self.0
-            .derive_sign_recoverable(self.1.derive(path), msg)
+        self.outer
+            .derive_sign_recoverable(self.inner.derive(path), msg)
             .await
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified signer derivation behavior: deriving from a sub-schema versus binding values directly to the current schema for signers that don’t require an extra derivation path.

- **Enhancements**
  - Improved recoverable signer support by automatically enabling implementations for common wrapper/reference forms (e.g., borrowed, boxed, and shared variants), making integration smoother while keeping existing usage consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->