### PR TITLE
fix: activate defuse-time schemars derive feature

### DIFF
--- a/crates/primitives/time/Cargo.toml
+++ b/crates/primitives/time/Cargo.toml
@@ -15,7 +15,7 @@ arbitrary = { workspace = true, optional = true }
 arbitrary_with = { workspace = true, optional = true }
 borsh = { workspace = true, optional = true }
 defuse-borsh-utils = { workspace = true, optional = true }
-schemars = { workspace = true, optional = true }
+schemars = { workspace = true, features = ["derive"], optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 serde_with = { workspace = true, optional = true }


### PR DESCRIPTION
Updated 'schemars' dependency to include 'derive' feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for generating schemas when the optional schema tooling is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->