### PR TITLE
Add unit tests for defuse-map-utils' DefaultMap cleanup semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,6 +1617,7 @@ version = "0.1.0"
 dependencies = [
  "impl-tools 0.12.0",
  "near-sdk",
+ "rstest",
 ]
 
 [[package]]

--- a/crates/map-utils/Cargo.toml
+++ b/crates/map-utils/Cargo.toml
@@ -16,3 +16,7 @@ near-sdk = { workspace = true, optional = true }
 
 [features]
 near = ["dep:near-sdk"]
+
+[dev-dependencies]
+near-sdk = { workspace = true, features = ["unit-testing"] }
+rstest.workspace = true

--- a/crates/map-utils/src/cleanup.rs
+++ b/crates/map-utils/src/cleanup.rs
@@ -273,3 +273,6 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/map-utils/src/cleanup/tests.rs
+++ b/crates/map-utils/src/cleanup/tests.rs
@@ -1,0 +1,117 @@
+use std::collections::HashMap;
+
+use super::*;
+
+#[test]
+fn vacant_entry_dropped_without_mutation_does_not_insert() {
+    let mut m: HashMap<&str, i32> = HashMap::new();
+    let _ = m.entry_or_default("a");
+    assert!(m.is_empty());
+}
+
+#[test]
+fn vacant_entry_mutated_to_nondefault_inserts_on_drop() {
+    let mut m: HashMap<&str, i32> = HashMap::new();
+    *m.entry_or_default("a") += 1;
+    assert_eq!(m.get("a"), Some(&1));
+    assert_eq!(m.len(), 1);
+}
+
+#[test]
+fn vacant_entry_mutated_back_to_default_does_not_insert() {
+    let mut m: HashMap<&str, i32> = HashMap::new();
+    {
+        let mut entry = m.entry_or_default("a");
+        *entry += 1;
+        *entry -= 1;
+    }
+    assert!(m.is_empty());
+}
+
+#[test]
+fn occupied_entry_at_default_removed_on_drop() {
+    let mut m: HashMap<&str, i32> = HashMap::new();
+    m.insert("a", 0);
+    let _ = m.entry_or_default("a");
+    assert!(m.is_empty());
+}
+
+#[test]
+fn occupied_entry_at_nondefault_kept_untouched_on_drop() {
+    let mut m: HashMap<&str, i32> = HashMap::new();
+    m.insert("a", 5);
+    let _ = m.entry_or_default("a");
+    assert_eq!(m.get("a"), Some(&5));
+}
+
+#[test]
+fn occupied_entry_mutated_to_default_removed_on_drop() {
+    let mut m: HashMap<&str, i32> = HashMap::new();
+    m.insert("a", 1);
+    *m.entry_or_default("a") -= 1;
+    assert!(m.is_empty());
+}
+
+#[test]
+fn occupied_entry_mutated_to_new_nondefault_updates_on_drop() {
+    let mut m: HashMap<&str, i32> = HashMap::new();
+    m.insert("a", 1);
+    *m.entry_or_default("a") += 4;
+    assert_eq!(m.get("a"), Some(&5));
+}
+
+#[test]
+fn key_returns_correct_key_for_vacant_entry() {
+    let mut m: HashMap<&str, i32> = HashMap::new();
+    assert_eq!(*m.entry_or_default("a").key(), "a");
+    // Reading the key alone must not insert anything.
+    assert!(m.is_empty());
+}
+
+#[test]
+fn key_returns_correct_key_for_occupied_entry() {
+    let mut m: HashMap<&str, i32> = HashMap::new();
+    m.insert("a", 5);
+    assert_eq!(*m.entry_or_default("a").key(), "a");
+}
+
+#[test]
+fn explicit_remove_on_vacant_returns_default_and_does_not_insert() {
+    let mut m: HashMap<&str, i32> = HashMap::new();
+    let removed = m.entry_or_default("a").remove();
+    assert_eq!(removed, 0);
+    assert!(m.is_empty());
+}
+
+#[test]
+fn explicit_remove_on_occupied_removes_and_returns_current_value() {
+    let mut m: HashMap<&str, i32> = HashMap::new();
+    m.insert("a", 7);
+    let removed = m.entry_or_default("a").remove();
+    assert_eq!(removed, 7);
+    assert!(m.is_empty());
+}
+
+#[test]
+fn deref_and_deref_mut_read_and_write_through_to_the_value() {
+    let mut m: HashMap<&str, i32> = HashMap::new();
+    let mut entry = m.entry_or_default("a");
+    assert_eq!(*entry, 0);
+    *entry = 42;
+    assert_eq!(*entry, 42);
+    drop(entry);
+    assert_eq!(m.get("a"), Some(&42));
+}
+
+#[test]
+fn multiple_keys_are_independent() {
+    let mut m: HashMap<&str, i32> = HashMap::new();
+    *m.entry_or_default("a") += 1;
+    let _ = m.entry_or_default("b"); // touched, but left at default -> not inserted
+    *m.entry_or_default("c") += 3;
+
+    assert_eq!(m.len(), 2);
+    assert_eq!(m.get("a"), Some(&1));
+    assert_eq!(m.get("b"), None);
+    assert_eq!(m.get("c"), Some(&3));
+}

--- a/crates/map-utils/src/cleanup/tests.rs
+++ b/crates/map-utils/src/cleanup/tests.rs
@@ -1,117 +1,193 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
+
+use rstest::rstest;
 
 use super::*;
+use crate::IterableMap;
 
-#[test]
-fn vacant_entry_dropped_without_mutation_does_not_insert() {
-    let mut m: HashMap<&str, i32> = HashMap::new();
-    let _ = m.entry_or_default("a");
+#[cfg(feature = "near")]
+fn near_iterable_map() -> near_sdk::store::IterableMap<String, i32> {
+    use near_sdk::{test_utils::VMContextBuilder, testing_env};
+
+    testing_env!(VMContextBuilder::new().build());
+    near_sdk::store::IterableMap::new(b"m".to_vec())
+}
+
+#[rstest]
+#[case::hash_map(HashMap::<String, i32>::new())]
+#[case::btree_map(BTreeMap::<String, i32>::new())]
+#[cfg_attr(feature = "near", case::near_iterable_map(near_iterable_map()))]
+fn vacant_entry_dropped_without_mutation_does_not_insert<M>(#[case] mut m: M)
+where
+    M: Map<K = String, V = i32> + IterableMap,
+{
+    let _ = m.entry_or_default("a".to_string());
     assert!(m.is_empty());
 }
 
-#[test]
-fn vacant_entry_mutated_to_nondefault_inserts_on_drop() {
-    let mut m: HashMap<&str, i32> = HashMap::new();
-    *m.entry_or_default("a") += 1;
-    assert_eq!(m.get("a"), Some(&1));
+#[rstest]
+#[case::hash_map(HashMap::<String, i32>::new())]
+#[case::btree_map(BTreeMap::<String, i32>::new())]
+#[cfg_attr(feature = "near", case::near_iterable_map(near_iterable_map()))]
+fn vacant_entry_mutated_to_nondefault_inserts_on_drop<M>(#[case] mut m: M)
+where
+    M: Map<K = String, V = i32> + IterableMap,
+{
+    *m.entry_or_default("a".to_string()) += 1;
+    assert_eq!(m.get(&"a".to_string()), Some(&1));
     assert_eq!(m.len(), 1);
 }
 
-#[test]
-fn vacant_entry_mutated_back_to_default_does_not_insert() {
-    let mut m: HashMap<&str, i32> = HashMap::new();
+#[rstest]
+#[case::hash_map(HashMap::<String, i32>::new())]
+#[case::btree_map(BTreeMap::<String, i32>::new())]
+#[cfg_attr(feature = "near", case::near_iterable_map(near_iterable_map()))]
+fn vacant_entry_mutated_back_to_default_does_not_insert<M>(#[case] mut m: M)
+where
+    M: Map<K = String, V = i32> + IterableMap,
+{
     {
-        let mut entry = m.entry_or_default("a");
+        let mut entry = m.entry_or_default("a".to_string());
         *entry += 1;
         *entry -= 1;
     }
     assert!(m.is_empty());
 }
 
-#[test]
-fn occupied_entry_at_default_removed_on_drop() {
-    let mut m: HashMap<&str, i32> = HashMap::new();
-    m.insert("a", 0);
-    let _ = m.entry_or_default("a");
+#[rstest]
+#[case::hash_map(HashMap::<String, i32>::new())]
+#[case::btree_map(BTreeMap::<String, i32>::new())]
+#[cfg_attr(feature = "near", case::near_iterable_map(near_iterable_map()))]
+fn occupied_entry_at_default_removed_on_drop<M>(#[case] mut m: M)
+where
+    M: Map<K = String, V = i32> + IterableMap,
+{
+    m.insert("a".to_string(), 0);
+    let _ = m.entry_or_default("a".to_string());
     assert!(m.is_empty());
 }
 
-#[test]
-fn occupied_entry_at_nondefault_kept_untouched_on_drop() {
-    let mut m: HashMap<&str, i32> = HashMap::new();
-    m.insert("a", 5);
-    let _ = m.entry_or_default("a");
-    assert_eq!(m.get("a"), Some(&5));
+#[rstest]
+#[case::hash_map(HashMap::<String, i32>::new())]
+#[case::btree_map(BTreeMap::<String, i32>::new())]
+#[cfg_attr(feature = "near", case::near_iterable_map(near_iterable_map()))]
+fn occupied_entry_at_nondefault_kept_untouched_on_drop<M>(#[case] mut m: M)
+where
+    M: Map<K = String, V = i32> + IterableMap,
+{
+    m.insert("a".to_string(), 5);
+    let _ = m.entry_or_default("a".to_string());
+    assert_eq!(m.get(&"a".to_string()), Some(&5));
 }
 
-#[test]
-fn occupied_entry_mutated_to_default_removed_on_drop() {
-    let mut m: HashMap<&str, i32> = HashMap::new();
-    m.insert("a", 1);
-    *m.entry_or_default("a") -= 1;
+#[rstest]
+#[case::hash_map(HashMap::<String, i32>::new())]
+#[case::btree_map(BTreeMap::<String, i32>::new())]
+#[cfg_attr(feature = "near", case::near_iterable_map(near_iterable_map()))]
+fn occupied_entry_mutated_to_default_removed_on_drop<M>(#[case] mut m: M)
+where
+    M: Map<K = String, V = i32> + IterableMap,
+{
+    m.insert("a".to_string(), 1);
+    *m.entry_or_default("a".to_string()) -= 1;
     assert!(m.is_empty());
 }
 
-#[test]
-fn occupied_entry_mutated_to_new_nondefault_updates_on_drop() {
-    let mut m: HashMap<&str, i32> = HashMap::new();
-    m.insert("a", 1);
-    *m.entry_or_default("a") += 4;
-    assert_eq!(m.get("a"), Some(&5));
+#[rstest]
+#[case::hash_map(HashMap::<String, i32>::new())]
+#[case::btree_map(BTreeMap::<String, i32>::new())]
+#[cfg_attr(feature = "near", case::near_iterable_map(near_iterable_map()))]
+fn occupied_entry_mutated_to_new_nondefault_updates_on_drop<M>(#[case] mut m: M)
+where
+    M: Map<K = String, V = i32> + IterableMap,
+{
+    m.insert("a".to_string(), 1);
+    *m.entry_or_default("a".to_string()) += 4;
+    assert_eq!(m.get(&"a".to_string()), Some(&5));
 }
 
-#[test]
-fn key_returns_correct_key_for_vacant_entry() {
-    let mut m: HashMap<&str, i32> = HashMap::new();
-    assert_eq!(*m.entry_or_default("a").key(), "a");
+#[rstest]
+#[case::hash_map(HashMap::<String, i32>::new())]
+#[case::btree_map(BTreeMap::<String, i32>::new())]
+#[cfg_attr(feature = "near", case::near_iterable_map(near_iterable_map()))]
+fn key_returns_correct_key_for_vacant_entry<M>(#[case] mut m: M)
+where
+    M: Map<K = String, V = i32> + IterableMap,
+{
+    assert_eq!(m.entry_or_default("a".to_string()).key(), "a");
     // Reading the key alone must not insert anything.
     assert!(m.is_empty());
 }
 
-#[test]
-fn key_returns_correct_key_for_occupied_entry() {
-    let mut m: HashMap<&str, i32> = HashMap::new();
-    m.insert("a", 5);
-    assert_eq!(*m.entry_or_default("a").key(), "a");
+#[rstest]
+#[case::hash_map(HashMap::<String, i32>::new())]
+#[case::btree_map(BTreeMap::<String, i32>::new())]
+#[cfg_attr(feature = "near", case::near_iterable_map(near_iterable_map()))]
+fn key_returns_correct_key_for_occupied_entry<M>(#[case] mut m: M)
+where
+    M: Map<K = String, V = i32> + IterableMap,
+{
+    m.insert("a".to_string(), 5);
+    assert_eq!(m.entry_or_default("a".to_string()).key(), "a");
 }
 
-#[test]
-fn explicit_remove_on_vacant_returns_default_and_does_not_insert() {
-    let mut m: HashMap<&str, i32> = HashMap::new();
-    let removed = m.entry_or_default("a").remove();
+#[rstest]
+#[case::hash_map(HashMap::<String, i32>::new())]
+#[case::btree_map(BTreeMap::<String, i32>::new())]
+#[cfg_attr(feature = "near", case::near_iterable_map(near_iterable_map()))]
+fn explicit_remove_on_vacant_returns_default_and_does_not_insert<M>(#[case] mut m: M)
+where
+    M: Map<K = String, V = i32> + IterableMap,
+{
+    let removed = m.entry_or_default("a".to_string()).remove();
     assert_eq!(removed, 0);
     assert!(m.is_empty());
 }
 
-#[test]
-fn explicit_remove_on_occupied_removes_and_returns_current_value() {
-    let mut m: HashMap<&str, i32> = HashMap::new();
-    m.insert("a", 7);
-    let removed = m.entry_or_default("a").remove();
+#[rstest]
+#[case::hash_map(HashMap::<String, i32>::new())]
+#[case::btree_map(BTreeMap::<String, i32>::new())]
+#[cfg_attr(feature = "near", case::near_iterable_map(near_iterable_map()))]
+fn explicit_remove_on_occupied_removes_and_returns_current_value<M>(#[case] mut m: M)
+where
+    M: Map<K = String, V = i32> + IterableMap,
+{
+    m.insert("a".to_string(), 7);
+    let removed = m.entry_or_default("a".to_string()).remove();
     assert_eq!(removed, 7);
     assert!(m.is_empty());
 }
 
-#[test]
-fn deref_and_deref_mut_read_and_write_through_to_the_value() {
-    let mut m: HashMap<&str, i32> = HashMap::new();
-    let mut entry = m.entry_or_default("a");
+#[rstest]
+#[case::hash_map(HashMap::<String, i32>::new())]
+#[case::btree_map(BTreeMap::<String, i32>::new())]
+#[cfg_attr(feature = "near", case::near_iterable_map(near_iterable_map()))]
+fn deref_and_deref_mut_read_and_write_through_to_the_value<M>(#[case] mut m: M)
+where
+    M: Map<K = String, V = i32> + IterableMap,
+{
+    let mut entry = m.entry_or_default("a".to_string());
     assert_eq!(*entry, 0);
     *entry = 42;
     assert_eq!(*entry, 42);
     drop(entry);
-    assert_eq!(m.get("a"), Some(&42));
+    assert_eq!(m.get(&"a".to_string()), Some(&42));
 }
 
-#[test]
-fn multiple_keys_are_independent() {
-    let mut m: HashMap<&str, i32> = HashMap::new();
-    *m.entry_or_default("a") += 1;
-    let _ = m.entry_or_default("b"); // touched, but left at default -> not inserted
-    *m.entry_or_default("c") += 3;
+#[rstest]
+#[case::hash_map(HashMap::<String, i32>::new())]
+#[case::btree_map(BTreeMap::<String, i32>::new())]
+#[cfg_attr(feature = "near", case::near_iterable_map(near_iterable_map()))]
+fn multiple_keys_are_independent<M>(#[case] mut m: M)
+where
+    M: Map<K = String, V = i32> + IterableMap,
+{
+    *m.entry_or_default("a".to_string()) += 1;
+    let _ = m.entry_or_default("b".to_string()); // touched, but left at default -> not inserted
+    *m.entry_or_default("c".to_string()) += 3;
 
     assert_eq!(m.len(), 2);
-    assert_eq!(m.get("a"), Some(&1));
-    assert_eq!(m.get("b"), None);
-    assert_eq!(m.get("c"), Some(&3));
+    assert_eq!(m.get(&"a".to_string()), Some(&1));
+    assert_eq!(m.get(&"b".to_string()), None);
+    assert_eq!(m.get(&"c".to_string()), Some(&3));
 }


### PR DESCRIPTION
## Summary

`crates/map-utils` has zero test files across ~1,150 lines. `cleanup.rs` in particular implements `DefaultMap::entry_or_default`, which relies on `Drop` to decide whether an entry actually stays in the underlying map:

- A **vacant** entry only gets inserted if it's mutated away from `Default` before being dropped.
- An **occupied** entry gets removed if it's mutated back to `Default` before being dropped.
- An explicit `.remove()` bypasses that `Drop` logic entirely (for a vacant entry it just discards the never-inserted default; for an occupied one it removes and returns the current value).

That logic was covered only by two doctests exercising a single happy path. This adds a proper unit test suite (`crates/map-utils/src/cleanup/tests.rs`) covering:

- Vacant entry dropped with/without mutation (insert vs. no-op)
- Vacant entry mutated then reverted back to default (no insert)
- Occupied entry dropped with/without mutation, and mutated to/away from default (remove vs. keep vs. update)
- Explicit `.remove()` on both vacant and occupied entries
- `.key()` on both entry kinds
- `Deref`/`DerefMut` read/write through
- Independence between multiple keys in the same map

No behavior changes — pure test addition.

## Verification
- `cargo test -p defuse-map-utils --lib`: 13 passed
- `cargo test -p defuse-map-utils --doc`: 3 passed (existing doctests, unaffected)
- `cargo clippy -p defuse-map-utils --all-targets -- -D warnings`: clean
- `cargo fmt -p defuse-map-utils -- --check`: clean
- Note: `cargo clippy -p defuse-map-utils --all-targets --all-features` (i.e. including the `near` feature) fails to compile locally on unrelated grounds — `near-sdk` v5.29.0 refuses to build outside a small set of cfgs (`cargo near build`, `cfg(clippy)`, etc.) — pre-existing and unrelated to this change; the `near` feature isn't touched here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for default map entry behavior across supported map types.
  * Tested insertion, mutation, removal, key access, dereferencing, and independent keys.
  * Verified that existing entries are preserved and updated correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->