### PR TITLE
chore: fix serialization of events when `near-contract` feature is disabled

### DIFF
--- a/contracts/global-deployer/src/events.rs
+++ b/contracts/global-deployer/src/events.rs
@@ -13,7 +13,8 @@ use near_account_id::AccountIdRef;
         // `#[near(event_json(...)))]` does it for us
         not(feature = "near-contract"),
         derive(::serde::Serialize),
-        serde(tag = "event", content = "data")
+        serde(tag = "event", content = "data", rename_all = "snake_case"),
+
     ),
     cfg_attr(feature = "near-contract", ::near_sdk::near(event_json(standard = "global-deployer")))
 )]

--- a/contracts/global-deployer/src/events.rs
+++ b/contracts/global-deployer/src/events.rs
@@ -14,7 +14,6 @@ use near_account_id::AccountIdRef;
         not(feature = "near-contract"),
         derive(::serde::Serialize),
         serde(tag = "event", content = "data", rename_all = "snake_case"),
-
     ),
     cfg_attr(feature = "near-contract", ::near_sdk::near(event_json(standard = "global-deployer")))
 )]

--- a/contracts/outlayer/app/src/events.rs
+++ b/contracts/outlayer/app/src/events.rs
@@ -13,7 +13,7 @@ use near_account_id::AccountIdRef;
         // `#[near(event_json(...)))]` does it for us
         not(feature = "near-contract"),
         derive(::serde::Serialize),
-        serde(tag = "event", content = "data")
+        serde(tag = "event", content = "data", rename_all = "snake_case"),
     ),
     cfg_attr(feature = "near-contract", ::near_sdk::near(event_json(standard = "outlayer-app")))
 )]

--- a/contracts/wallet/src/events.rs
+++ b/contracts/wallet/src/events.rs
@@ -15,7 +15,7 @@ use near_account_id::AccountIdRef;
         // `#[near(event_json(...)))]` does it for us
         not(feature = "near-contract"),
         derive(::serde::Serialize),
-        serde(tag = "event", content = "data")
+        serde(tag = "event", content = "data", rename_all = "snake_case"),
     ),
     cfg_attr(feature = "near-contract", ::near_sdk::near(event_json(standard = "wallet")))
 )]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized serialized event names to use `snake_case` across global deployer, outlayer, and wallet events.
  * Preserved the existing event tags and data fields for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->