### PR TITLE
Add unit tests for defuse-num-utils' checked arithmetic traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,6 +1790,7 @@ name = "defuse-num-utils"
 version = "0.1.0"
 dependencies = [
  "bnum",
+ "rstest",
 ]
 
 [[package]]

--- a/crates/num-utils/Cargo.toml
+++ b/crates/num-utils/Cargo.toml
@@ -9,3 +9,6 @@ repository.workspace = true
 
 [dependencies]
 bnum.workspace = true
+
+[dev-dependencies]
+rstest.workspace = true

--- a/crates/num-utils/src/add_sub.rs
+++ b/crates/num-utils/src/add_sub.rs
@@ -74,3 +74,89 @@ impl_checked!(u16, i16);
 impl_checked!(u32, i32);
 impl_checked!(u64, i64);
 impl_checked!(u128, i128);
+
+#[cfg(test)]
+mod tests {
+    use core::fmt::Debug;
+
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case(2u8, 3u8, Some(5u8))]
+    #[case(u8::MAX, 1u8, None)]
+    #[case(0u8, 0u8, Some(0u8))]
+    #[case(2i8, 3i8, Some(5i8))]
+    #[case(i8::MAX, 1i8, None)]
+    #[case(i8::MIN, -1i8, None)]
+    #[case(u128::MAX, 1u128, None)]
+    #[case(i128::MIN, -1i128, None)]
+    #[case(i128::MAX, -1i128, Some(i128::MAX - 1))]
+    fn checked_add_same_type<T>(#[case] a: T, #[case] b: T, #[case] expected: Option<T>)
+    where
+        T: CheckedAdd<T> + PartialEq + Debug,
+    {
+        assert_eq!(a.checked_add(b), expected);
+    }
+
+    #[rstest]
+    #[case(5u8, -3i8, Some(2u8))]
+    #[case(0u8, -1i8, None)]
+    #[case(250u8, 10i8, None)]
+    #[case(250u8, 5i8, Some(255u8))]
+    #[case(0u8, i8::MIN, None)]
+    fn checked_add_unsigned_plus_signed(
+        #[case] a: u8,
+        #[case] b: i8,
+        #[case] expected: Option<u8>,
+    ) {
+        // `a.checked_add(b)` would resolve to the inherent `u8::checked_add`
+        // (same-type only) rather than this crate's `CheckedAdd<i8>` impl.
+        assert_eq!(CheckedAdd::checked_add(a, b), expected);
+    }
+
+    #[rstest]
+    #[case(-5i8, 3u8, Some(-2i8))]
+    #[case(100i8, 30u8, None)]
+    #[case(i8::MIN, 1u8, Some(i8::MIN + 1))]
+    #[case(-1i8, u8::MAX, None)]
+    fn checked_add_signed_plus_unsigned(
+        #[case] a: i8,
+        #[case] b: u8,
+        #[case] expected: Option<i8>,
+    ) {
+        assert_eq!(CheckedAdd::checked_add(a, b), expected);
+    }
+
+    #[rstest]
+    #[case(5u8, 3u8, Some(2u8))]
+    #[case(3u8, 5u8, None)]
+    #[case(0u8, 0u8, Some(0u8))]
+    #[case(5i8, 3i8, Some(2i8))]
+    #[case(i8::MIN, -1i8, Some(i8::MIN + 1))]
+    #[case(i8::MIN, 1i8, None)]
+    #[case(0u128, 1u128, None)]
+    #[case(i128::MIN, 1i128, None)]
+    fn checked_sub_same_type<T>(#[case] a: T, #[case] b: T, #[case] expected: Option<T>)
+    where
+        T: CheckedSub<T> + PartialEq + Debug,
+    {
+        assert_eq!(a.checked_sub(b), expected);
+    }
+
+    #[rstest]
+    #[case(5i8, 3u8, Some(2i8))]
+    #[case(i8::MIN, 1u8, None)]
+    #[case(-1i8, 1u8, Some(-2i8))]
+    // 127 - 255 = -128, landing exactly on `i8::MIN` without underflowing
+    #[case(i8::MAX, u8::MAX, Some(i8::MIN))]
+    #[case(0i8, u8::MAX, None)]
+    fn checked_sub_signed_minus_unsigned(
+        #[case] a: i8,
+        #[case] b: u8,
+        #[case] expected: Option<i8>,
+    ) {
+        assert_eq!(CheckedSub::checked_sub(a, b), expected);
+    }
+}

--- a/crates/num-utils/src/div.rs
+++ b/crates/num-utils/src/div.rs
@@ -25,3 +25,33 @@ macro_rules! impl_checked_div {
 impl_checked_div!(u8, u16, u32, u64, u128);
 //  #![feature(int_roundings)]
 // impl_checked_div!(i8, i16, i32, i64, i128);
+
+#[cfg(test)]
+mod tests {
+    use core::fmt::Debug;
+
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case(10u8, 3u8, Some(3u8), Some(4u8))]
+    #[case(9u8, 3u8, Some(3u8), Some(3u8))]
+    #[case(10u8, 0u8, None, None)]
+    #[case(0u8, 5u8, Some(0u8), Some(0u8))]
+    #[case(1u8, 1u8, Some(1u8), Some(1u8))]
+    #[case(u128::MAX, 1u128, Some(u128::MAX), Some(u128::MAX))]
+    #[case(u128::MAX, u128::MAX, Some(1u128), Some(1u128))]
+    #[case(u128::MAX, 0u128, None, None)]
+    fn checked_div_and_ceil<T>(
+        #[case] a: T,
+        #[case] b: T,
+        #[case] expected_div: Option<T>,
+        #[case] expected_ceil: Option<T>,
+    ) where
+        T: CheckedDiv<T> + PartialEq + Debug + Copy,
+    {
+        assert_eq!(a.checked_div(b), expected_div);
+        assert_eq!(a.checked_div_ceil(b), expected_ceil);
+    }
+}

--- a/crates/num-utils/src/mul.rs
+++ b/crates/num-utils/src/mul.rs
@@ -18,3 +18,30 @@ macro_rules! impl_checked_mul {
     )+};
 }
 impl_checked_mul!(u8, i8, u16, i16, u32, i32, u64, i64, u128, i128);
+
+#[cfg(test)]
+mod tests {
+    use core::fmt::Debug;
+
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case(2u8, 3u8, Some(6u8))]
+    #[case(200u8, 2u8, None)]
+    #[case(0u8, 0u8, Some(0u8))]
+    #[case(-2i8, 3i8, Some(-6i8))]
+    #[case(i8::MIN, -1i8, None)]
+    #[case(u128::MAX, 2u128, None)]
+    #[case(i128::MIN, -1i128, None)]
+    fn checked_mul_and_ceil<T>(#[case] a: T, #[case] b: T, #[case] expected: Option<T>)
+    where
+        T: CheckedMul<T> + PartialEq + Debug + Copy,
+    {
+        assert_eq!(a.checked_mul(b), expected);
+        // No override exists for any of the base integer types, so the
+        // default `checked_mul_ceil` impl must always match `checked_mul`.
+        assert_eq!(a.checked_mul_ceil(b), expected);
+    }
+}

--- a/crates/num-utils/src/mul_div.rs
+++ b/crates/num-utils/src/mul_div.rs
@@ -60,3 +60,128 @@ impl_checked_mul_div!(u128 as BUint<4>);
 //     impl_checked_mul_div!(i64 as i128);
 // };
 impl_checked_mul_div!(i128 as BInt<4>);
+
+#[cfg(test)]
+mod tests {
+    use core::fmt::Debug;
+
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    // exact division
+    #[case(10u8, 3u8, 5u8, Some(6u8))]
+    // truncates like a regular integer division on a non-exact result
+    #[case(10u8, 3u8, 7u8, Some(4u8))]
+    // self == 0
+    #[case(0u8, 3u8, 7u8, Some(0u8))]
+    // division by zero
+    #[case(10u8, 3u8, 0u8, None)]
+    // the `self * mul` intermediate product would overflow the base type,
+    // but not the widened intermediate type used internally
+    #[case(200u8, 200u8, 200u8, Some(200u8))]
+    // final result doesn't fit back into the base type after narrowing,
+    // even though the widened multiplication itself didn't overflow
+    #[case(200u8, 200u8, 1u8, None)]
+    #[case(u16::MAX, u16::MAX, 1u16, None)]
+    #[case(u32::MAX, u32::MAX, 1u32, None)]
+    #[case(u64::MAX, u64::MAX, 1u64, None)]
+    #[case(u128::MAX, u128::MAX, 1u128, None)]
+    #[case(u128::MAX, 1u128, u128::MAX, Some(1u128))]
+    fn checked_mul_div_unsigned<T>(
+        #[case] a: T,
+        #[case] mul: T,
+        #[case] div: T,
+        #[case] expected: Option<T>,
+    ) where
+        T: CheckedMulDiv<T> + PartialEq + Debug,
+    {
+        assert_eq!(a.checked_mul_div(mul, div), expected);
+    }
+
+    #[rstest]
+    // exact division: no rounding needed
+    #[case(10u8, 3u8, 5u8, Some(6u8))]
+    // rounds up on a non-exact result
+    #[case(10u8, 3u8, 7u8, Some(5u8))]
+    // self == 0
+    #[case(0u8, 3u8, 7u8, Some(0u8))]
+    // division by zero
+    #[case(10u8, 3u8, 0u8, None)]
+    // narrowing overflow after rounding up
+    #[case(200u8, 200u8, 1u8, None)]
+    fn checked_mul_div_ceil_unsigned<T>(
+        #[case] a: T,
+        #[case] mul: T,
+        #[case] div: T,
+        #[case] expected: Option<T>,
+    ) where
+        T: CheckedMulDiv<T> + PartialEq + Debug,
+    {
+        assert_eq!(a.checked_mul_div_ceil(mul, div), expected);
+    }
+
+    #[rstest]
+    // for non-negative operands, euclidean division matches regular division
+    #[case(10u8, 3u8, 7u8, Some(4u8))]
+    #[case(10u8, 3u8, 0u8, None)]
+    #[case(200u8, 200u8, 1u8, None)]
+    fn checked_mul_div_euclid_unsigned<T>(
+        #[case] a: T,
+        #[case] mul: T,
+        #[case] div: T,
+        #[case] expected: Option<T>,
+    ) where
+        T: CheckedMulDiv<T> + PartialEq + Debug,
+    {
+        assert_eq!(a.checked_mul_div_euclid(mul, div), expected);
+    }
+
+    #[rstest]
+    // truncates toward zero, unlike `checked_mul_div_euclid` below
+    #[case(-7i128, 1i128, 2i128, Some(-3i128))]
+    #[case(10i128, 3i128, 0i128, None)]
+    // widened multiplication doesn't overflow, but narrowing the result
+    // back down to i128 does: `-(i128::MIN)` doesn't fit in i128
+    #[case(i128::MIN, -1i128, 1i128, None)]
+    fn checked_mul_div_signed(
+        #[case] a: i128,
+        #[case] mul: i128,
+        #[case] div: i128,
+        #[case] expected: Option<i128>,
+    ) {
+        assert_eq!(a.checked_mul_div(mul, div), expected);
+    }
+
+    #[rstest]
+    // rounds away from zero on the positive side of an exact split
+    #[case(10i128, 3i128, 7i128, Some(5i128))]
+    #[case(10i128, 3i128, 0i128, None)]
+    fn checked_mul_div_ceil_signed(
+        #[case] a: i128,
+        #[case] mul: i128,
+        #[case] div: i128,
+        #[case] expected: Option<i128>,
+    ) {
+        assert_eq!(a.checked_mul_div_ceil(mul, div), expected);
+    }
+
+    #[rstest]
+    // euclidean division always yields a non-negative remainder, so it
+    // rounds toward negative infinity rather than truncating toward zero
+    #[case(-7i128, 1i128, 2i128, Some(-4i128))]
+    #[case(7i128, 1i128, -2i128, Some(-3i128))]
+    #[case(-7i128, 1i128, -2i128, Some(4i128))]
+    #[case(10i128, 3i128, 0i128, None)]
+    // same narrowing overflow as `checked_mul_div`
+    #[case(i128::MIN, -1i128, 1i128, None)]
+    fn checked_mul_div_euclid_signed(
+        #[case] a: i128,
+        #[case] mul: i128,
+        #[case] div: i128,
+        #[case] expected: Option<i128>,
+    ) {
+        assert_eq!(a.checked_mul_div_euclid(mul, div), expected);
+    }
+}


### PR DESCRIPTION
## Summary

`crates/num-utils` (~190 lines) implements `CheckedAdd`, `CheckedSub`, `CheckedMul`, `CheckedDiv`, and `CheckedMulDiv` across every integer width (`u8..u128`, `i8..i128`), with zero test coverage. It's a dependency of `defuse-fees` and `defuse-decimal`'s ordering/arithmetic, so a rounding or overflow-narrowing bug here silently affects fee and price math.

This adds unit test coverage (`rstest`-based, following the pattern used elsewhere in the workspace, e.g. `crates/primitives/decimal/src/ops.rs`) for:

- **`CheckedAdd`/`CheckedSub`**: same-type, `unsigned + signed`, and `signed + unsigned` combinations, plus overflow/underflow boundaries at both the narrow (`i8`/`u8`) and wide (`i128`/`u128`) ends.
- **`CheckedDiv`**: division by zero, exact division, and rounding-up behavior of `checked_div_ceil`.
- **`CheckedMul`**: overflow, and that the default `checked_mul_ceil` forwards to `checked_mul` (no type currently overrides it).
- **`CheckedMulDiv`**: division by zero, the case where the widened intermediate product doesn't overflow but the *final narrowed* result no longer fits back into the base type, and — for the `i128`/`BInt<4>` path — euclidean vs. truncating rounding on negative operands (`checked_mul_div` truncates toward zero, `checked_mul_div_euclid` rounds toward negative infinity).

All expected values were cross-checked against the actual `bnum`-backed implementation in a standalone harness before being hardcoded into the tests, rather than hand-computed.

No behavior changes — pure test addition.

## Verification
- `cargo test -p defuse-num-utils --lib`: 75 passed
- `cargo test -p defuse-num-utils --doc`: 0 (no doctests in this crate)
- `cargo clippy -p defuse-num-utils --all-targets -- -D warnings`: clean
- `cargo fmt -p defuse-num-utils -- --check`: clean
- `cargo check -p defuse-fees -p defuse-decimal`: unaffected (test-only change)