### PR TITLE
feat(wallet): eip712 variant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,6 +1509,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "defuse-eip712"
+version = "0.1.0"
+dependencies = [
+ "defuse-crypto",
+ "defuse-digest",
+ "hex-literal",
+ "k256 0.14.0",
+ "rstest",
+ "tokio",
+]
+
+[[package]]
 name = "defuse-erc191"
 version = "0.1.0"
 dependencies = [
@@ -2074,6 +2086,31 @@ dependencies = [
  "rand 0.10.2",
  "rstest",
  "tokio",
+ "tokio-test",
+]
+
+[[package]]
+name = "defuse-wallet-eip712"
+version = "0.1.0"
+dependencies = [
+ "borsh",
+ "defuse-crypto",
+ "defuse-digest",
+ "defuse-eip712",
+ "defuse-wallet",
+ "defuse-wallet-eip712",
+ "defuse-wallet-sdk",
+ "derive_more",
+ "hex",
+ "hex-literal",
+ "k256 0.14.0",
+ "near-sdk",
+ "rstest",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.19",
  "tokio-test",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "contracts/treasury-logger",
   "contracts/wallet",
   "contracts/wallet/signatures/ed25519",
+  "contracts/wallet/signatures/eip712",
   "contracts/wallet/signatures/no-sign",
   "contracts/wallet/signatures/webauthn",
   "contracts/wallet/signatures/webauthn/ed25519",
@@ -47,6 +48,7 @@ members = [
   "crates/primitives/time",
   "crates/primitives/token-id",
 
+  "crates/signatures/eip712",
   "crates/signatures/erc191",
   "crates/signatures/nep413",
   "crates/signatures/nep461",
@@ -82,6 +84,7 @@ defuse-poa-factory.path = "contracts/poa/factory"
 defuse-poa-token.path = "contracts/poa/token"
 defuse-wallet.path = "contracts/wallet"
 defuse-wallet-ed25519.path = "contracts/wallet/signatures/ed25519"
+defuse-wallet-eip712.path = "contracts/wallet/signatures/eip712"
 defuse-wallet-no-sign.path = "contracts/wallet/signatures/no-sign"
 defuse-wallet-webauthn.path = "contracts/wallet/signatures/webauthn"
 defuse-wallet-webauthn-ed25519.path = "contracts/wallet/signatures/webauthn/ed25519"
@@ -118,6 +121,7 @@ defuse-fees.path = "crates/primitives/fees"
 defuse-time = { path = "crates/primitives/time", default-features = false }
 defuse-token-id = { path = "crates/primitives/token-id", default-features = false }
 
+defuse-eip712.path = "crates/signatures/eip712"
 defuse-erc191.path = "crates/signatures/erc191"
 defuse-nep413.path = "crates/signatures/nep413"
 defuse-nep461.path = "crates/signatures/nep461"

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ CONTRACT_CRATES := \
     defuse-poa-factory \
     defuse-poa-token \
     defuse-wallet-ed25519 \
+    defuse-wallet-eip712 \
     defuse-wallet-no-sign \
     defuse-wallet-webauthn-ed25519 \
     defuse-wallet-webauthn-p256 \

--- a/contracts/wallet/README.md
+++ b/contracts/wallet/README.md
@@ -15,8 +15,10 @@ A generic minimalistic wallet smart-contract that enables for true *sharded* and
   added/removed by the signer or other installed extensions. Enables 2FA, social
   recovery and more.
 * Can support *any* [**signing standards**](#signing-standards). As of now, we
-  have support for **passkeys** (both `p256` and `ed25519`). Additional variants
-  can be implemented by *anyone* in the future.
+  have support for **passkeys** (both `p256` and `ed25519`) and **Ethereum
+  wallets** via [EIP-712](https://eips.ethereum.org/EIPS/eip-712)
+  (`eth_signTypedData_v4`), with clear signing. Additional variants can be
+  implemented by *anyone* in the future.
 * **Non-sequential** timeout-based [nonces](#nonces) enable *concurrent* request
   and avoid head-of-line blocking.
 * `AccountIds` are [deterministically derived](https://github.com/near/NEPs/blob/master/neps/nep-0616.md#deterministic-accountids)
@@ -58,6 +60,20 @@ is fixed at the time of a deployment. Each variant is deployed as a
 A public key of the wallet contract instance is also fixed at the time of first
 initialization and **cannot** be changed later. However, signature can still be
 disabled by signer/extension (see [key rotation](#key-rotation)).
+
+A variant MAY store a *derivative* of the public key instead, as long as each
+proof still binds the key: the `eip712` variant stores the signer's `0x`
+Ethereum address and derives it from the public key it recovers from the proof.
+Ethereum wallets expose the address without any signing ceremony, so a client
+knows the wallet's deterministic `AccountId` as soon as the user connects.
+
+Most standards sign the *canonical digest* of the message
+(`SHA3-256(domain || borsh(msg))`), since general-purpose signers (e.g. passkey
+authenticators) implement blind signing anyway. **Clear-signing** standards
+(e.g. [EIP-712](https://eips.ethereum.org/EIPS/eip-712), where the wallet
+displays the structure being signed) instead bind the proof to the *contents*
+of the message: their schemas verify that the signed structure denotes exactly
+the message the contract is about to act upon.
 
 ### Extensions
 

--- a/contracts/wallet/signatures/eip712/Cargo.toml
+++ b/contracts/wallet/signatures/eip712/Cargo.toml
@@ -1,0 +1,78 @@
+lints.workspace = true
+
+[package]
+name = "defuse-wallet-eip712"
+edition.workspace = true
+version = "0.1.0"
+rust-version.workspace = true
+repository.workspace = true
+readme = "../README.md"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+defuse-crypto = { workspace = true, features = ["borsh", "secp256k1", "serde"] }
+defuse-digest = { workspace = true, features = ["sha3"] }
+defuse-eip712.workspace = true
+defuse-wallet = { workspace = true, features = ["borsh", "digest", "json", "serde"] }
+
+borsh = { workspace = true, features = ["derive"] }
+derive_more = { workspace = true, features = ["as_ref", "from", "into"] }
+hex.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+serde_with.workspace = true
+thiserror.workspace = true
+
+defuse-wallet-sdk = { workspace = true, optional = true }
+hex-literal = { workspace = true, optional = true }
+near-sdk = { workspace = true, optional = true }
+schemars = { workspace = true, features = ["derive"], optional = true }
+
+[features]
+abi = [
+  "borsh/unstable__schema",
+  "defuse-crypto/abi",
+  "defuse-wallet/abi",
+  "dep:hex-literal",
+  "dep:schemars",
+  "near-sdk?/abi",
+]
+
+signer = ["defuse-crypto/signing", "dep:defuse-wallet-sdk"]
+
+contract = [
+  "defuse-crypto/borsh",
+  "defuse-wallet/near-contract",
+  "dep:near-sdk",
+]
+
+[dev-dependencies]
+defuse-wallet-eip712 = { path = ".", features = ["abi", "signer", "contract"] }
+
+hex-literal.workspace = true
+k256 = { workspace = true, features = ["getrandom"] }
+rstest.workspace = true
+tokio-test.workspace = true
+
+near-sdk = { workspace = true, features = ["unit-testing"] }
+
+[package.metadata.near.reproducible_build]
+image = "sourcescan/cargo-near:0.22.0-rust-1.97.1"
+image_digest = "sha256:7467038bdddc86484b73b416eeadce926ff59013e128e53dec5a19e1cb4b2234"
+passed_env = []
+container_build_command = [
+  "cargo",
+  "near",
+  "build",
+  "non-reproducible-wasm",
+  "--locked",
+  "--no-default-features",
+  "--features=contract",
+  "--abi-features=abi,contract",
+]
+
+[package.metadata.cargo-machete]
+# needed for `wallet!` macro, since `#[near(...)]` doesn't support re-exports
+ignored = ["near-sdk"]

--- a/contracts/wallet/signatures/eip712/src/address.rs
+++ b/contracts/wallet/signatures/eip712/src/address.rs
@@ -1,0 +1,182 @@
+use core::{
+    fmt::{self, Debug, Display},
+    str::FromStr,
+};
+
+use defuse_crypto::secp256k1::{Secp256k1UncompressedPublicKey, k256::ecdsa::VerifyingKey};
+use defuse_digest::{Digest, sha3::Keccak256};
+use serde_with::{DeserializeFromStr, SerializeDisplay};
+
+/// [Ethereum address](https://ethereum.org/en/developers/docs/accounts/#account-creation),
+/// i.e. the last 20 bytes of `keccak256(uncompressed_public_key)`, stored in
+/// the [state](defuse_wallet::State) of the
+/// [`WalletEip712`](crate::WalletEip712) contract variant.
+///
+/// # Why the address and not the public key
+///
+/// Ethereum wallets expose the *address* (e.g. `eth_requestAccounts`), while
+/// the public key can only be recovered from a signature. Since the
+/// [deterministic `AccountId`](https://github.com/near/NEPs/blob/master/neps/nep-0616.md)
+/// of a wallet-contract instance is derived from its initial state, storing
+/// the address means a client knows its NEAR account id right away — without
+/// a preliminary signing ceremony just to learn the public key.
+///
+/// The contract recovers the public key from the proof and derives this
+/// address from it, so the binding to the key is preserved.
+#[cfg_attr(
+    feature = "abi",
+    derive(::borsh::BorshSchema, ::schemars::JsonSchema),
+    schemars(example = "Self::example")
+)]
+#[derive(
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    SerializeDisplay,
+    DeserializeFromStr,
+    ::borsh::BorshSerialize,
+    ::borsh::BorshDeserialize,
+    derive_more::AsRef,
+    derive_more::From,
+    derive_more::Into,
+)]
+#[as_ref([u8], [u8; 20])]
+#[into(owned, ref)]
+#[repr(transparent)]
+pub struct EthAddress(
+    // schemars@0.8 ignores `with` at struct level for newtypes; must be on the field
+    #[cfg_attr(feature = "abi", schemars(with = "String"))] pub [u8; 20],
+);
+
+impl EthAddress {
+    #[cfg(feature = "abi")]
+    const fn example() -> Self {
+        Self(::hex_literal::hex!(
+            "d8da6bf26964af9d7eed9e03e53415d37aa96045"
+        ))
+    }
+}
+
+impl From<&Secp256k1UncompressedPublicKey> for EthAddress {
+    #[inline]
+    fn from(public_key: &Secp256k1UncompressedPublicKey) -> Self {
+        Self(
+            Keccak256::digest(public_key)[12..]
+                .try_into()
+                .unwrap_or_else(|_| unreachable!()),
+        )
+    }
+}
+
+impl From<Secp256k1UncompressedPublicKey> for EthAddress {
+    #[inline]
+    fn from(public_key: Secp256k1UncompressedPublicKey) -> Self {
+        (&public_key).into()
+    }
+}
+
+impl From<&VerifyingKey> for EthAddress {
+    #[inline]
+    fn from(public_key: &VerifyingKey) -> Self {
+        Secp256k1UncompressedPublicKey::from(public_key).into()
+    }
+}
+
+impl Display for EthAddress {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "0x{}", hex::encode(self.0))
+    }
+}
+
+impl Debug for EthAddress {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl FromStr for EthAddress {
+    type Err = ParseEthAddressError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.strip_prefix("0x").ok_or(ParseEthAddressError::NoPrefix)?;
+
+        let mut address = [0u8; 20];
+        // accepts both lowercase and EIP-55 checksummed (mixed-case) hex,
+        // without verifying the checksum
+        hex::decode_to_slice(s, &mut address)?;
+
+        Ok(Self(address))
+    }
+}
+
+/// An error returned while parsing an [`EthAddress`].
+#[derive(Debug, thiserror::Error)]
+pub enum ParseEthAddressError {
+    #[error("missing '0x' prefix")]
+    NoPrefix,
+
+    #[error(transparent)]
+    Hex(#[from] hex::FromHexError),
+}
+
+#[cfg(test)]
+mod tests {
+    use hex_literal::hex;
+    use rstest::rstest;
+
+    use super::*;
+
+    /// Known-answer vector: `0x` addresses MUST be derived exactly as on
+    /// Ethereum, so that the wallet is controlled by the very same key the
+    /// user already has.
+    #[rstest]
+    #[case(
+        hex!("85a66984273f338ce4ef7b85e5430b008307e8591bb7c1b980852cf6423770b801f41e9438155eb53a5e20f748640093bb42ae3aeca035f7b7fd7a1a21f22f68"),
+        "0x0551f7c9a91ee579c9e40444ffc490001c323108"
+    )]
+    fn derive(
+        #[case] public_key: impl Into<Secp256k1UncompressedPublicKey>,
+        #[case] address: &str,
+    ) {
+        assert_eq!(EthAddress::from(public_key.into()).to_string(), address);
+    }
+
+    /// Derivation all the way from a private key, cross-checked against an
+    /// independent secp256k1 + keccak256 implementation.
+    #[rstest]
+    fn derive_from_private_key() {
+        let key = defuse_crypto::secp256k1::k256::ecdsa::SigningKey::from_bytes(
+            &hex!("4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318").into(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            EthAddress::from(key.verifying_key()).to_string(),
+            "0x2c7536e3605d9c16a7a3d7b1898e529396a65c23",
+        );
+    }
+
+    #[rstest]
+    #[case("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")]
+    #[case("0xd8da6bf26964af9d7eed9e03e53415d37aa96045")]
+    fn parse(#[case] s: &str) {
+        assert_eq!(
+            EthAddress::from_str(s).unwrap(),
+            EthAddress(hex!("d8da6bf26964af9d7eed9e03e53415d37aa96045")),
+        );
+    }
+
+    #[rstest]
+    #[case::no_prefix("d8da6bf26964af9d7eed9e03e53415d37aa96045")]
+    #[case::too_short("0xd8da6bf26964af9d7eed9e03e53415d37aa960")]
+    #[case::not_hex("0xzzda6bf26964af9d7eed9e03e53415d37aa96045")]
+    fn parse_fail(#[case] s: &str) {
+        assert!(EthAddress::from_str(s).is_err());
+    }
+}

--- a/contracts/wallet/signatures/eip712/src/contract.rs
+++ b/contracts/wallet/signatures/eip712/src/contract.rs
@@ -1,0 +1,13 @@
+use defuse_wallet::wallet;
+
+use crate::WalletEip712;
+
+wallet! {
+    #[wallet(
+        schema = WalletEip712,
+        metadata(
+            standard(standard = "wallet-eip712", version = "1.0.0")
+        )
+    )]
+    struct Contract(_);
+}

--- a/contracts/wallet/signatures/eip712/src/lib.rs
+++ b/contracts/wallet/signatures/eip712/src/lib.rs
@@ -57,15 +57,20 @@ pub const DOMAIN: Eip712Domain<'static> = Eip712Domain {
 /// [`w_resolve_auth()`](defuse_wallet::offchain::AuthResolver::w_resolve_auth)),
 /// so the wallet displays what is actually going to be executed or authorized.
 ///
+/// The request contents are *unpacked* into the typed data: each
+/// [wallet operation](Eip712WalletOp) and [promise](Eip712NearPromise) (with
+/// its [actions](Eip712NearAction)) is a typed structure of its own, so the
+/// wallet renders them structurally instead of one opaque JSON blob. Only the
+/// leaf `payload`s remain JSON.
+///
 /// The contract does not trust that display: it checks every member of the
 /// signed typed data against the message it is about to act upon (see
 /// [`Eip712RequestMessage::matches()`] and [`Eip712AuthMessage::matches()`]),
 /// so a proof whose typed data says anything other than the message is
-/// rejected. Members carrying nested structures
-/// ([`internal`](Eip712RequestMessage::internal) and
-/// [`external`](Eip712RequestMessage::external)) are compared *semantically*,
-/// i.e. by parsing them and comparing the values, so clients are free to
-/// format that JSON as they like (e.g. pretty-print it for display).
+/// rejected. Leaf `payload`s are compared *semantically*: JSON whitespace and
+/// key order are free (e.g. pretty-print them for display), but any extra
+/// field the contract would ignore invalidates the proof, so the wallet can
+/// never display more than what gets executed.
 ///
 /// # Proof
 ///
@@ -227,6 +232,12 @@ mod tests {
             NearPromise::new("eve.near".parse::<AccountId>().unwrap())
                 .transfer(NearToken::from_near(1)),
         ];
+    })]
+    #[case::external_receiver(|msg: &mut RequestMessage| {
+        msg.request.external[0].receiver_id = "eve.near".parse().unwrap();
+    })]
+    #[case::external_refund_to(|msg: &mut RequestMessage| {
+        msg.request.external[0].refund_to = Some("eve.near".parse().unwrap());
     })]
     fn verify_request_tampered(#[case] tamper: fn(&mut RequestMessage)) {
         let signed = request_msg();

--- a/contracts/wallet/signatures/eip712/src/lib.rs
+++ b/contracts/wallet/signatures/eip712/src/lib.rs
@@ -1,0 +1,347 @@
+mod address;
+#[cfg(feature = "contract")]
+mod contract;
+mod message;
+#[cfg(feature = "signer")]
+mod signer;
+#[cfg(feature = "signer")]
+pub use self::signer::*;
+
+pub use self::{address::*, message::*};
+
+pub use defuse_crypto as crypto;
+pub use defuse_eip712 as eip712;
+
+use defuse_crypto::secp256k1::{Secp256k1UncompressedPublicKey, k256};
+use defuse_eip712::{Eip712, Eip712Domain};
+use defuse_wallet::{RequestMessage, SignatureSchema, offchain::OffchainMessage};
+use serde::de::DeserializeOwned;
+
+/// [EIP-712](https://eips.ethereum.org/EIPS/eip-712) domain of all messages
+/// signed for wallet contracts.
+pub const DOMAIN: Eip712Domain<'static> = Eip712Domain {
+    name: "NEAR Wallet Contract",
+    version: "1",
+};
+
+/// [EIP-712](https://eips.ethereum.org/EIPS/eip-712) (`eth_signTypedData_v4`)
+/// wallet [signature schema](SignatureSchema).
+///
+/// It allows any Ethereum wallet (e.g. `MetaMask`, `WalletConnect`, Ledger)
+/// to be used as the sole key of a NEAR wallet-contract account.
+///
+/// # Identity: address, not public key
+///
+/// The contract stores the signer's [Ethereum address](EthAddress) in its
+/// [state](defuse_wallet::State) and derives it from the public key recovered
+/// from each proof, so the binding to the key is preserved.
+///
+/// Ethereum wallets hand out the address without any signing ceremony (e.g.
+/// `eth_requestAccounts`), while the public key can only be recovered from a
+/// signature. Since the deterministic NEAR `AccountId` commits to the initial
+/// state, storing the address lets a client know which account it controls as
+/// soon as the user connects — one roundtrip less. It also keeps 44 bytes
+/// more of the [ZBA](https://github.com/near/NEPs/blob/master/neps/nep-0448.md)
+/// budget free.
+///
+/// [`w_public_key()`](defuse_wallet::contract::Wallet::w_public_key) returns
+/// this address as `0x<hex>`.
+///
+/// # Clear signing
+///
+/// The signer never signs an opaque digest: the typed data mirrors the
+/// *contents* of the message being authorized
+/// ([`Eip712RequestMessage`] for
+/// [`w_execute_signed()`](defuse_wallet::contract::Wallet::w_execute_signed),
+/// [`Eip712AuthMessage`] for
+/// [`w_resolve_auth()`](defuse_wallet::offchain::AuthResolver::w_resolve_auth)),
+/// so the wallet displays what is actually going to be executed or authorized.
+///
+/// The contract does not trust that display: it checks every member of the
+/// signed typed data against the message it is about to act upon (see
+/// [`Eip712RequestMessage::matches()`] and [`Eip712AuthMessage::matches()`]),
+/// so a proof whose typed data says anything other than the message is
+/// rejected. Members carrying nested structures
+/// ([`internal`](Eip712RequestMessage::internal) and
+/// [`external`](Eip712RequestMessage::external)) are compared *semantically*,
+/// i.e. by parsing them and comparing the values, so clients are free to
+/// format that JSON as they like (e.g. pretty-print it for display).
+///
+/// # Proof
+///
+/// `proof` is a JSON-serialized [`SignedEip712`], i.e. the signed typed data
+/// `message` along with a recoverable 65-byte secp256k1 `signature`
+/// (`r ‖ s ‖ v`, where `v` is the recovery id `0`/`1`) formatted as
+/// `secp256k1:<base58>`.
+///
+/// Note that Ethereum wallets return `v` as `27`/`28`, so clients MUST
+/// normalize it by subtracting `27`.
+pub struct WalletEip712;
+
+impl WalletEip712 {
+    /// Recover the public key that signed given [proof](SignedEip712) along
+    /// with the typed data it committed to.
+    fn recover<M>(proof: &str) -> Option<(M, Secp256k1UncompressedPublicKey)>
+    where
+        M: Eip712Message + DeserializeOwned,
+    {
+        let SignedEip712::<M> { message, signature } = serde_json::from_str(proof).ok()?;
+
+        let (signature, recovery_id) =
+            <(k256::ecdsa::Signature, k256::ecdsa::RecoveryId)>::try_from(&signature).ok()?;
+
+        let public_key = Eip712::recover(
+            &DOMAIN.separator(),
+            &message.struct_hash(),
+            &signature,
+            recovery_id,
+        )?;
+
+        Some((message, public_key.into()))
+    }
+}
+
+impl SignatureSchema for WalletEip712 {
+    /// The [Ethereum address](EthAddress) of the signer, derived from the
+    /// public key recovered from the proof.
+    type PublicKey = EthAddress;
+
+    fn verify_request_msg(address: &Self::PublicKey, msg: &RequestMessage, proof: &str) -> bool {
+        Self::recover::<Eip712RequestMessage>(proof).is_some_and(|(signed, recovered)| {
+            EthAddress::from(recovered) == *address && signed.matches(msg)
+        })
+    }
+
+    fn verify_offchain_msg(address: &Self::PublicKey, msg: &OffchainMessage, proof: &str) -> bool {
+        Self::recover::<Eip712AuthMessage>(proof).is_some_and(|(signed, recovered)| {
+            EthAddress::from(recovered) == *address && signed.matches(msg)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::time::Duration;
+
+    use defuse_wallet::{
+        AccountId, NearPromise, NearToken, Request, Timestamp, WalletOp, offchain::OffchainMessage,
+    };
+    use defuse_wallet_sdk::WalletSigner;
+    use hex_literal::hex;
+    use rstest::rstest;
+
+    use super::*;
+
+    fn signer() -> WalletEip712Signer<k256::ecdsa::SigningKey> {
+        WalletEip712Signer(
+            k256::ecdsa::SigningKey::from_bytes(
+                &hex!("4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318").into(),
+            )
+            .unwrap(),
+        )
+    }
+
+    fn address() -> EthAddress {
+        WalletSigner::<WalletEip712>::public_key(&signer())
+    }
+
+    fn request_msg() -> RequestMessage {
+        RequestMessage {
+            pay_for_gas: false,
+            chain_id: "mainnet".to_string(),
+            signer_id: "0s0000000000000000000000000000000000000000"
+                .parse()
+                .unwrap(),
+            nonce: 42,
+            created_at: Timestamp::UNIX_EPOCH,
+            timeout: Duration::from_hours(1),
+            request: Request::new()
+                .internal([WalletOp::AddExtension {
+                    account_id: "extension.near".parse::<AccountId>().unwrap(),
+                }])
+                .external([NearPromise::new("bob.near".parse::<AccountId>().unwrap())
+                    .transfer(NearToken::from_near(1))]),
+        }
+    }
+
+    fn offchain_msg() -> OffchainMessage {
+        OffchainMessage {
+            chain_id: "mainnet".to_string(),
+            signer_id: "0s0000000000000000000000000000000000000000"
+                .parse()
+                .unwrap(),
+            path: vec!["master.near".parse().unwrap()],
+            timestamp: Timestamp::UNIX_EPOCH,
+            payload: "Login to example.app at 2026-07-16T00:00:00Z".to_string(),
+        }
+    }
+
+    fn sign_request(msg: &RequestMessage) -> String {
+        tokio_test::block_on(WalletSigner::sign_request_msg(&signer(), msg)).unwrap()
+    }
+
+    fn sign_offchain(msg: &OffchainMessage) -> String {
+        tokio_test::block_on(WalletSigner::<WalletEip712>::sign_offchain_msg(
+            &signer(),
+            msg,
+        ))
+        .unwrap()
+    }
+
+    #[rstest]
+    fn verify_request_ok() {
+        let msg = request_msg();
+        assert!(
+            WalletEip712::verify_request_msg(&address(), &msg, &sign_request(&msg)),
+            "signature is invalid",
+        );
+    }
+
+    #[rstest]
+    fn verify_offchain_ok() {
+        let msg = offchain_msg();
+        assert!(
+            WalletEip712::verify_offchain_msg(&address(), &msg, &sign_offchain(&msg)),
+            "signature is invalid",
+        );
+    }
+
+    /// The typed data the signer sees MUST bind every field of the message
+    /// the contract acts upon.
+    #[rstest]
+    #[case::pay_for_gas(|msg: &mut RequestMessage| msg.pay_for_gas = !msg.pay_for_gas)]
+    #[case::chain_id(|msg: &mut RequestMessage| msg.chain_id = "testnet".to_string())]
+    #[case::signer_id(|msg: &mut RequestMessage| {
+        msg.signer_id = "0s1111111111111111111111111111111111111111".parse().unwrap();
+    })]
+    #[case::nonce(|msg: &mut RequestMessage| msg.nonce += 1)]
+    #[case::created_at(|msg: &mut RequestMessage| {
+        msg.created_at = msg.created_at.saturating_add_unsigned(Duration::from_secs(1));
+    })]
+    #[case::timeout(|msg: &mut RequestMessage| msg.timeout = Duration::from_mins(1))]
+    #[case::internal(|msg: &mut RequestMessage| {
+        msg.request.internal = vec![WalletOp::SetSignatureMode { enable: false }];
+    })]
+    #[case::external(|msg: &mut RequestMessage| {
+        msg.request.external = vec![
+            NearPromise::new("eve.near".parse::<AccountId>().unwrap())
+                .transfer(NearToken::from_near(1)),
+        ];
+    })]
+    fn verify_request_tampered(#[case] tamper: fn(&mut RequestMessage)) {
+        let signed = request_msg();
+        let proof = sign_request(&signed);
+
+        let mut executed = signed;
+        tamper(&mut executed);
+
+        assert!(
+            !WalletEip712::verify_request_msg(&address(), &executed, &proof),
+            "proof verified against a message other than the signed one",
+        );
+    }
+
+    #[rstest]
+    #[case::chain_id(|msg: &mut OffchainMessage| msg.chain_id = "testnet".to_string())]
+    #[case::signer_id(|msg: &mut OffchainMessage| {
+        msg.signer_id = "0s1111111111111111111111111111111111111111".parse().unwrap();
+    })]
+    #[case::path_replaced(|msg: &mut OffchainMessage| {
+        msg.path = vec!["eve.near".parse().unwrap()];
+    })]
+    #[case::path_extended(|msg: &mut OffchainMessage| {
+        msg.path.push("v1.signer".parse().unwrap());
+    })]
+    #[case::path_top_level(|msg: &mut OffchainMessage| msg.path.clear())]
+    #[case::timestamp(|msg: &mut OffchainMessage| {
+        msg.timestamp = msg.timestamp.saturating_add_unsigned(Duration::from_secs(1));
+    })]
+    #[case::payload(|msg: &mut OffchainMessage| msg.payload = "something else".to_string())]
+    fn verify_offchain_tampered(#[case] tamper: fn(&mut OffchainMessage)) {
+        let signed = offchain_msg();
+        let proof = sign_offchain(&signed);
+
+        let mut resolved = signed;
+        tamper(&mut resolved);
+
+        assert!(
+            !WalletEip712::verify_offchain_msg(&address(), &resolved, &proof),
+            "proof verified against a message other than the signed one",
+        );
+    }
+
+    /// Both message kinds live under the same EIP-712 domain, so they MUST be
+    /// separated by their primary type.
+    #[rstest]
+    fn no_cross_type_replay() {
+        assert!(
+            !WalletEip712::verify_offchain_msg(
+                &address(),
+                &offchain_msg(),
+                &sign_request(&request_msg()),
+            ),
+            "request proof was accepted as an authorization",
+        );
+        assert!(
+            !WalletEip712::verify_request_msg(
+                &address(),
+                &request_msg(),
+                &sign_offchain(&offchain_msg()),
+            ),
+            "authorization proof was accepted as a request",
+        );
+    }
+
+    #[rstest]
+    fn other_address() {
+        let msg = request_msg();
+        assert!(
+            !WalletEip712::verify_request_msg(
+                &EthAddress(hex!("d8da6bf26964af9d7eed9e03e53415d37aa96045")),
+                &msg,
+                &sign_request(&msg),
+            ),
+            "proof verified against another address",
+        );
+    }
+
+    #[rstest]
+    #[case::malformed("not-a-proof")]
+    #[case::bare_signature(
+        "secp256k1:7ND3TQwc9NkuqYQpjkR6cWJmDjndsDzZJukMcCwSVs4iWuMxCFJTsRoevHhSMwFHZoTrbn1wHu6mSQVWr4H7EJvV"
+    )]
+    #[case::other_curve(
+        r#"{"message":{},"signature":"ed25519:5wHqR6FiZCotbRfPRskG8RzDRkmFmZy9Wweh4vBtZp8eTJ2TPq6rFY9oc6nZyVmEFEPxoxNwVF9pZd1JN84m7m5me"}"#
+    )]
+    fn malformed_proof(#[case] proof: &str) {
+        assert!(
+            !WalletEip712::verify_request_msg(&address(), &request_msg(), proof),
+            "malformed proof passed verification",
+        );
+    }
+
+    /// The NEAR `AccountId` of a wallet-contract instance is derived from its
+    /// initial state, which holds the signer's *address* — so a client that
+    /// only did `eth_requestAccounts` (no signing ceremony) can already tell
+    /// which account it controls.
+    #[rstest]
+    fn account_id_derivable_from_address_alone() {
+        use defuse_wallet_sdk::{GlobalContractId, State, StateInit, StateInitV1, Wallet};
+
+        const CODE: GlobalContractId = GlobalContractId::CodeHash(hex!(
+            "0000000000000000000000000000000000000000000000000000000000000000"
+        ));
+
+        // what a client can compute knowing nothing but the `0x` address
+        let derived = StateInit::V1(StateInitV1 {
+            code: CODE,
+            data: State::new(address()).as_storage(),
+        })
+        .derive_account_id();
+
+        assert_eq!(
+            derived,
+            *Wallet::<WalletEip712>::new(CODE, signer()).account_id(),
+        );
+    }
+}

--- a/contracts/wallet/signatures/eip712/src/message.rs
+++ b/contracts/wallet/signatures/eip712/src/message.rs
@@ -13,7 +13,9 @@ use crate::DOMAIN;
 /// A typed data structure signed under the wallet-contract
 /// [domain](crate::DOMAIN).
 pub trait Eip712Message {
-    /// `encodeType(typeOf(s))`, i.e. the primary type of this structure.
+    /// `encodeType(typeOf(s))`, i.e. the primary type of this structure
+    /// followed by the definitions of all referenced struct types, sorted
+    /// alphabetically.
     ///
     /// Since all wallet-contract messages share a single
     /// [domain](crate::DOMAIN), the primary type is what separates them from
@@ -47,6 +49,11 @@ pub struct SignedEip712<M> {
 /// Typed data mirroring a [`RequestMessage`], signed for
 /// [`w_execute_signed()`](defuse_wallet::contract::Wallet::w_execute_signed).
 ///
+/// The request contents are *unpacked* into typed structures
+/// ([`Eip712WalletOp`], [`Eip712NearPromise`], [`Eip712NearAction`]), so the
+/// Ethereum wallet renders each operation and promise structurally instead of
+/// one opaque JSON blob. Only the leaf `payload`s remain JSON.
+///
 /// ```json
 /// {
 ///   "types": {
@@ -55,36 +62,56 @@ pub struct SignedEip712<M> {
 ///       { "name": "version", "type": "string" }
 ///     ],
 ///     "WalletRequest": [
-///       { "name": "payForGas", "type": "bool" },
 ///       { "name": "chainId", "type": "string" },
 ///       { "name": "signerId", "type": "string" },
 ///       { "name": "nonce", "type": "uint32" },
 ///       { "name": "createdAt", "type": "string" },
 ///       { "name": "timeoutSecs", "type": "uint32" },
-///       { "name": "internal", "type": "string" },
-///       { "name": "external", "type": "string" }
+///       { "name": "internal", "type": "WalletOp[]" },
+///       { "name": "external", "type": "NearPromise[]" },
+///       { "name": "payForGas", "type": "bool" }
+///     ],
+///     "WalletOp": [
+///       { "name": "op", "type": "string" },
+///       { "name": "payload", "type": "string" }
+///     ],
+///     "NearPromise": [
+///       { "name": "receiverId", "type": "string" },
+///       { "name": "refundTo", "type": "string" },
+///       { "name": "actions", "type": "NearAction[]" }
+///     ],
+///     "NearAction": [
+///       { "name": "action", "type": "string" },
+///       { "name": "payload", "type": "string" }
 ///     ]
 ///   },
 ///   "primaryType": "WalletRequest",
 ///   "domain": { "name": "NEAR Wallet Contract", "version": "1" },
 ///   "message": {
-///     "payForGas": false,
 ///     "chainId": "mainnet",
 ///     "signerId": "0s0000000000000000000000000000000000000000",
 ///     "nonce": 42,
 ///     "createdAt": "1970-01-01T00:00:00Z",
 ///     "timeoutSecs": 3600,
-///     "internal": "[{\"op\":\"add_extension\",\"payload\":{\"account_id\":\"extension.near\"}}]",
-///     "external": "[]"
+///     "internal": [
+///       { "op": "add_extension", "payload": "{\"account_id\":\"extension.near\"}" }
+///     ],
+///     "external": [
+///       {
+///         "receiverId": "bob.near",
+///         "refundTo": "",
+///         "actions": [
+///           { "action": "transfer", "payload": "{\"deposit\":\"1000000000000000000000000\"}" }
+///         ]
+///       }
+///     ],
+///     "payForGas": false
 ///   }
 /// }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Eip712RequestMessage {
-    /// [`RequestMessage::pay_for_gas`]
-    pub pay_for_gas: bool,
-
     /// [`RequestMessage::chain_id`]
     pub chain_id: String,
 
@@ -100,31 +127,39 @@ pub struct Eip712RequestMessage {
     /// [`RequestMessage::timeout`] in seconds
     pub timeout_secs: u32,
 
-    /// JSON-serialized [`Request::internal`](defuse_wallet::Request::internal),
-    /// i.e. the list of [wallet operations](WalletOp) to apply.
-    pub internal: String,
+    /// [`Request::internal`](defuse_wallet::Request::internal), i.e. the list
+    /// of [wallet operations](WalletOp) to apply.
+    pub internal: Vec<Eip712WalletOp>,
 
-    /// JSON-serialized [`Request::external`](defuse_wallet::Request::external),
-    /// i.e. the list of [promises](NearPromise) to execute.
-    pub external: String,
+    /// [`Request::external`](defuse_wallet::Request::external), i.e. the list
+    /// of [promises](NearPromise) to execute.
+    pub external: Vec<Eip712NearPromise>,
+
+    /// [`RequestMessage::pay_for_gas`]
+    ///
+    /// The member is always part of the signed type (EIP-712 has no optional
+    /// members), but it MAY be omitted from the JSON representation, in which
+    /// case it defaults to `false`.
+    #[serde(default)]
+    pub pay_for_gas: bool,
 }
 
 impl Eip712Message for Eip712RequestMessage {
-    const ENCODE_TYPE: &'static str = "WalletRequest(bool payForGas,string chainId,string signerId,uint32 nonce,string createdAt,uint32 timeoutSecs,string internal,string external)";
+    const ENCODE_TYPE: &'static str = "WalletRequest(string chainId,string signerId,uint32 nonce,string createdAt,uint32 timeoutSecs,WalletOp[] internal,NearPromise[] external,bool payForGas)NearAction(string action,string payload)NearPromise(string receiverId,string refundTo,NearAction[] actions)WalletOp(string op,string payload)";
 
     #[inline]
     fn struct_hash(&self) -> Hash {
         Eip712::hash_struct(
             &Eip712::type_hash(Self::ENCODE_TYPE),
             [
-                Eip712::encode_bool(self.pay_for_gas),
                 Eip712::encode_bytes(&self.chain_id),
                 Eip712::encode_bytes(&self.signer_id),
                 Eip712::encode_uint(self.nonce),
                 Eip712::encode_bytes(&self.created_at),
                 Eip712::encode_uint(self.timeout_secs),
-                Eip712::encode_bytes(&self.internal),
-                Eip712::encode_bytes(&self.external),
+                Eip712::encode_array(self.internal.iter().map(Eip712WalletOp::struct_hash)),
+                Eip712::encode_array(self.external.iter().map(Eip712NearPromise::struct_hash)),
+                Eip712::encode_bool(self.pay_for_gas),
             ],
         )
     }
@@ -134,38 +169,204 @@ impl Eip712RequestMessage {
     /// Returns whether this typed data denotes exactly given [`RequestMessage`],
     /// i.e. whether the signer authorized this very message.
     ///
-    /// Members carrying nested structures ([`internal`](Self::internal) and
-    /// [`external`](Self::external)) are compared *semantically*, so their
-    /// JSON formatting doesn't have to be canonical.
+    /// Leaf `payload`s are compared *semantically* (see
+    /// [`Eip712WalletOp::matches()`]), so their JSON formatting doesn't have
+    /// to be canonical.
     #[must_use]
     pub fn matches(&self, msg: &RequestMessage) -> bool {
-        self.pay_for_gas == msg.pay_for_gas
-            && self.chain_id == msg.chain_id
+        self.chain_id == msg.chain_id
             && self.signer_id == msg.signer_id.as_str()
             && self.nonce == msg.nonce
             && matches_timestamp(&self.created_at, msg.created_at)
             && matches_timeout(self.timeout_secs, msg.timeout)
-            && serde_json::from_str::<Vec<WalletOp>>(&self.internal)
-                .is_ok_and(|internal| internal == msg.request.internal)
-            && serde_json::from_str::<Vec<NearPromise>>(&self.external)
-                .is_ok_and(|external| external == msg.request.external)
+            && self.internal.len() == msg.request.internal.len()
+            && self
+                .internal
+                .iter()
+                .zip(&msg.request.internal)
+                .all(|(op, expected)| op.matches(expected))
+            && self.external.len() == msg.request.external.len()
+            && self
+                .external
+                .iter()
+                .zip(&msg.request.external)
+                .all(|(promise, expected)| promise.matches(expected))
+            && self.pay_for_gas == msg.pay_for_gas
     }
 }
 
 impl From<&RequestMessage> for Eip712RequestMessage {
     fn from(msg: &RequestMessage) -> Self {
         Self {
-            pay_for_gas: msg.pay_for_gas,
             chain_id: msg.chain_id.clone(),
             signer_id: msg.signer_id.to_string(),
             nonce: msg.nonce,
             created_at: msg.created_at.to_string(),
             timeout_secs: msg.timeout.as_secs().try_into().unwrap_or(u32::MAX),
-            internal: serde_json::to_string(&msg.request.internal)
-                .unwrap_or_else(|_| unreachable!()),
-            external: serde_json::to_string(&msg.request.external)
-                .unwrap_or_else(|_| unreachable!()),
+            internal: msg.request.internal.iter().map(Into::into).collect(),
+            external: msg.request.external.iter().map(Into::into).collect(),
+            pay_for_gas: msg.pay_for_gas,
         }
+    }
+}
+
+/// Typed data mirroring a [`WalletOp`]: the operation tag along with its
+/// JSON-serialized payload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Eip712WalletOp {
+    /// The operation tag, e.g. `add_extension`.
+    pub op: String,
+
+    /// JSON-serialized operation payload, e.g.
+    /// `{"account_id":"extension.near"}`.
+    pub payload: String,
+}
+
+impl Eip712WalletOp {
+    /// `encodeType(WalletOp)`
+    pub const ENCODE_TYPE: &'static str = "WalletOp(string op,string payload)";
+
+    /// `hashStruct(s) = keccak256(typeHash ‖ encodeData(s))`
+    #[inline]
+    pub fn struct_hash(&self) -> Hash {
+        Eip712::hash_struct(
+            &Eip712::type_hash(Self::ENCODE_TYPE),
+            [
+                Eip712::encode_bytes(&self.op),
+                Eip712::encode_bytes(&self.payload),
+            ],
+        )
+    }
+
+    /// Returns whether this typed data denotes exactly given [`WalletOp`].
+    ///
+    /// The [`payload`](Self::payload) is compared *semantically* against the
+    /// canonical serialization of `expected`: JSON whitespace and key order
+    /// are free, but the set of fields must match exactly — extra fields
+    /// (which the contract would otherwise silently ignore) invalidate the
+    /// proof, so the wallet can never display more than what gets executed.
+    #[must_use]
+    pub fn matches(&self, expected: &WalletOp) -> bool {
+        let expected = Self::from(expected);
+        self.op == expected.op && matches_json(&self.payload, &expected.payload)
+    }
+}
+
+impl From<&WalletOp> for Eip712WalletOp {
+    fn from(op: &WalletOp) -> Self {
+        let (op, payload) = split_tagged(op, "op");
+        Self { op, payload }
+    }
+}
+
+/// Typed data mirroring a [`NearPromise`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Eip712NearPromise {
+    /// [`NearPromise::receiver_id`]
+    pub receiver_id: String,
+
+    /// [`NearPromise::refund_to`], or an empty string if not set.
+    pub refund_to: String,
+
+    /// [`NearPromise::actions`]
+    pub actions: Vec<Eip712NearAction>,
+}
+
+impl Eip712NearPromise {
+    /// `encodeType(NearPromise)`, including the referenced
+    /// [`NearAction`](Eip712NearAction) type.
+    pub const ENCODE_TYPE: &'static str = "NearPromise(string receiverId,string refundTo,NearAction[] actions)NearAction(string action,string payload)";
+
+    /// `hashStruct(s) = keccak256(typeHash ‖ encodeData(s))`
+    #[inline]
+    pub fn struct_hash(&self) -> Hash {
+        Eip712::hash_struct(
+            &Eip712::type_hash(Self::ENCODE_TYPE),
+            [
+                Eip712::encode_bytes(&self.receiver_id),
+                Eip712::encode_bytes(&self.refund_to),
+                Eip712::encode_array(self.actions.iter().map(Eip712NearAction::struct_hash)),
+            ],
+        )
+    }
+
+    /// Returns whether this typed data denotes exactly given [`NearPromise`].
+    #[must_use]
+    pub fn matches(&self, expected: &NearPromise) -> bool {
+        self.receiver_id == expected.receiver_id.as_str()
+            && expected
+                .refund_to
+                .as_ref()
+                .map_or(self.refund_to.is_empty(), |refund_to| {
+                    self.refund_to == refund_to.as_str()
+                })
+            && self.actions.len() == expected.actions.len()
+            && self
+                .actions
+                .iter()
+                .zip(&expected.actions)
+                .all(|(action, expected)| action.matches(expected))
+    }
+}
+
+impl From<&NearPromise> for Eip712NearPromise {
+    fn from(promise: &NearPromise) -> Self {
+        Self {
+            receiver_id: promise.receiver_id.to_string(),
+            refund_to: promise
+                .refund_to
+                .as_ref()
+                .map(ToString::to_string)
+                .unwrap_or_default(),
+            actions: promise.actions.iter().map(Into::into).collect(),
+        }
+    }
+}
+
+/// Typed data mirroring a [`NearAction`](defuse_wallet::actions::NearAction):
+/// the action tag along with its JSON-serialized payload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Eip712NearAction {
+    /// The action tag, e.g. `function_call` or `transfer`.
+    pub action: String,
+
+    /// JSON-serialized action payload, e.g. `{"deposit":"1"}`.
+    pub payload: String,
+}
+
+impl Eip712NearAction {
+    /// `encodeType(NearAction)`
+    pub const ENCODE_TYPE: &'static str = "NearAction(string action,string payload)";
+
+    /// `hashStruct(s) = keccak256(typeHash ‖ encodeData(s))`
+    #[inline]
+    pub fn struct_hash(&self) -> Hash {
+        Eip712::hash_struct(
+            &Eip712::type_hash(Self::ENCODE_TYPE),
+            [
+                Eip712::encode_bytes(&self.action),
+                Eip712::encode_bytes(&self.payload),
+            ],
+        )
+    }
+
+    /// Returns whether this typed data denotes exactly given
+    /// [`NearAction`](defuse_wallet::actions::NearAction).
+    ///
+    /// The [`payload`](Self::payload) is compared *semantically*, see
+    /// [`Eip712WalletOp::matches()`].
+    #[must_use]
+    pub fn matches(&self, expected: &defuse_wallet::actions::NearAction) -> bool {
+        let expected = Self::from(expected);
+        self.action == expected.action && matches_json(&self.payload, &expected.payload)
+    }
+}
+
+impl From<&defuse_wallet::actions::NearAction> for Eip712NearAction {
+    fn from(action: &defuse_wallet::actions::NearAction) -> Self {
+        let (action, payload) = split_tagged(action, "action");
+        Self { action, payload }
     }
 }
 
@@ -268,6 +469,32 @@ impl From<&OffchainMessage> for Eip712AuthMessage {
     }
 }
 
+/// Split an adjacently-tagged enum (`{"<tag>": ..., "payload": ...}`) into
+/// its tag and JSON-serialized payload.
+fn split_tagged<T: Serialize>(value: &T, tag: &str) -> (String, String) {
+    let Ok(serde_json::Value::Object(mut value)) = serde_json::to_value(value) else {
+        unreachable!()
+    };
+    let Some(serde_json::Value::String(tag)) = value.remove(tag) else {
+        unreachable!()
+    };
+    (
+        tag,
+        value
+            .remove("payload")
+            .unwrap_or(serde_json::Value::Null)
+            .to_string(),
+    )
+}
+
+#[inline]
+fn matches_json(payload: &str, expected: &str) -> bool {
+    serde_json::from_str::<serde_json::Value>(payload).is_ok_and(|payload| {
+        serde_json::from_str::<serde_json::Value>(expected)
+            .is_ok_and(|expected| payload == expected)
+    })
+}
+
 #[inline]
 fn matches_timestamp(s: &str, timestamp: Timestamp) -> bool {
     Timestamp::from_str(s).is_ok_and(|parsed| parsed == timestamp)
@@ -280,23 +507,58 @@ fn matches_timeout(secs: u32, timeout: core::time::Duration) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use defuse_wallet::AccountId;
     use hex_literal::hex;
     use rstest::rstest;
 
     use super::*;
 
-    /// Known-answer vectors: pin the primary types used on-chain.
+    /// Known-answer vectors: pin the types used on-chain.
     /// Recomputing them differently is a breaking change to the wire format.
     #[rstest]
     #[case(
         Eip712RequestMessage::ENCODE_TYPE,
-        hex!("1dd8d3b498246adfecef1936d8120de268cc04e0dc5c6a0fe5a3fffd0597e0c8")
+        hex!("547aceeba23d203514552238ee8823c6e7e6814bfbb1e6e8a27e81d6daa647ef")
     )]
     #[case(
         Eip712AuthMessage::ENCODE_TYPE,
         hex!("ac4a66d331a12e85c8b62dba6474cc9d52c755fa73733f4e240c8d55275b1ab7")
     )]
+    #[case(
+        Eip712WalletOp::ENCODE_TYPE,
+        hex!("0f38fbf4200e398513656e5bc84307fbc293cbd4e127ac9933efc5bdfa12e90e")
+    )]
+    #[case(
+        Eip712NearPromise::ENCODE_TYPE,
+        hex!("36e572508f92fd050ca143bc789ee5ed2fae8b9a957a2dadf570fae1f4bfbd43")
+    )]
+    #[case(
+        Eip712NearAction::ENCODE_TYPE,
+        hex!("ab11cc9fe3361446286c15450dcef46668a54853d2430d3b16f3bd7711e34ada")
+    )]
     fn type_hash(#[case] encode_type: &str, #[case] expected: Hash) {
         assert_eq!(Eip712::type_hash(encode_type), expected);
+    }
+
+    /// Leaf `payload`s are compared semantically: whitespace and key order
+    /// are free, but any extra field the contract would ignore invalidates
+    /// the proof.
+    #[rstest]
+    #[case::canonical(r#"{"account_id":"extension.near"}"#, true)]
+    #[case::pretty("{\n  \"account_id\": \"extension.near\"\n}", true)]
+    #[case::extra_field(r#"{"account_id":"extension.near","note":"looks safe"}"#, false)]
+    #[case::other_value(r#"{"account_id":"eve.near"}"#, false)]
+    #[case::not_json("add extension.near", false)]
+    fn payload_semantic_comparison(#[case] payload: &str, #[case] matches: bool) {
+        let op = WalletOp::add_extension("extension.near".parse::<AccountId>().unwrap());
+
+        assert_eq!(
+            Eip712WalletOp {
+                op: "add_extension".to_string(),
+                payload: payload.to_string(),
+            }
+            .matches(&op),
+            matches,
+        );
     }
 }

--- a/contracts/wallet/signatures/eip712/src/message.rs
+++ b/contracts/wallet/signatures/eip712/src/message.rs
@@ -1,0 +1,302 @@
+//! [EIP-712](https://eips.ethereum.org/EIPS/eip-712) typed data signed for
+//! wallet contracts.
+
+use core::str::FromStr;
+
+use defuse_crypto::secp256k1::Secp256k1RecoverableSignature;
+use defuse_eip712::{Eip712, Hash};
+use defuse_wallet::{NearPromise, RequestMessage, Timestamp, WalletOp, offchain::OffchainMessage};
+use serde::{Deserialize, Serialize};
+
+use crate::DOMAIN;
+
+/// A typed data structure signed under the wallet-contract
+/// [domain](crate::DOMAIN).
+pub trait Eip712Message {
+    /// `encodeType(typeOf(s))`, i.e. the primary type of this structure.
+    ///
+    /// Since all wallet-contract messages share a single
+    /// [domain](crate::DOMAIN), the primary type is what separates them from
+    /// each other.
+    const ENCODE_TYPE: &'static str;
+
+    /// `hashStruct(s) = keccak256(typeHash ‖ encodeData(s))`
+    fn struct_hash(&self) -> Hash;
+
+    /// `keccak256(0x19 ‖ 0x01 ‖ domainSeparator ‖ hashStruct(s))`, i.e. the
+    /// digest an Ethereum wallet signs for this structure.
+    #[inline]
+    fn prehash(&self) -> Hash {
+        Eip712::prehash(&DOMAIN.separator(), &self.struct_hash())
+    }
+}
+
+/// Signed [EIP-712](https://eips.ethereum.org/EIPS/eip-712) typed data, used
+/// as the `proof` of [`WalletEip712`](crate::WalletEip712).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignedEip712<M> {
+    /// The signed typed data, i.e. the `message` of the
+    /// `eth_signTypedData_v4` request.
+    pub message: M,
+
+    /// Recoverable 65-byte secp256k1 signature over
+    /// [`message.prehash()`](Eip712Message::prehash).
+    pub signature: Secp256k1RecoverableSignature,
+}
+
+/// Typed data mirroring a [`RequestMessage`], signed for
+/// [`w_execute_signed()`](defuse_wallet::contract::Wallet::w_execute_signed).
+///
+/// ```json
+/// {
+///   "types": {
+///     "EIP712Domain": [
+///       { "name": "name", "type": "string" },
+///       { "name": "version", "type": "string" }
+///     ],
+///     "WalletRequest": [
+///       { "name": "payForGas", "type": "bool" },
+///       { "name": "chainId", "type": "string" },
+///       { "name": "signerId", "type": "string" },
+///       { "name": "nonce", "type": "uint32" },
+///       { "name": "createdAt", "type": "string" },
+///       { "name": "timeoutSecs", "type": "uint32" },
+///       { "name": "internal", "type": "string" },
+///       { "name": "external", "type": "string" }
+///     ]
+///   },
+///   "primaryType": "WalletRequest",
+///   "domain": { "name": "NEAR Wallet Contract", "version": "1" },
+///   "message": {
+///     "payForGas": false,
+///     "chainId": "mainnet",
+///     "signerId": "0s0000000000000000000000000000000000000000",
+///     "nonce": 42,
+///     "createdAt": "1970-01-01T00:00:00Z",
+///     "timeoutSecs": 3600,
+///     "internal": "[{\"op\":\"add_extension\",\"payload\":{\"account_id\":\"extension.near\"}}]",
+///     "external": "[]"
+///   }
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Eip712RequestMessage {
+    /// [`RequestMessage::pay_for_gas`]
+    pub pay_for_gas: bool,
+
+    /// [`RequestMessage::chain_id`]
+    pub chain_id: String,
+
+    /// [`RequestMessage::signer_id`]
+    pub signer_id: String,
+
+    /// [`RequestMessage::nonce`]
+    pub nonce: u32,
+
+    /// [`RequestMessage::created_at`] in RFC-3339 format
+    pub created_at: String,
+
+    /// [`RequestMessage::timeout`] in seconds
+    pub timeout_secs: u32,
+
+    /// JSON-serialized [`Request::internal`](defuse_wallet::Request::internal),
+    /// i.e. the list of [wallet operations](WalletOp) to apply.
+    pub internal: String,
+
+    /// JSON-serialized [`Request::external`](defuse_wallet::Request::external),
+    /// i.e. the list of [promises](NearPromise) to execute.
+    pub external: String,
+}
+
+impl Eip712Message for Eip712RequestMessage {
+    const ENCODE_TYPE: &'static str = "WalletRequest(bool payForGas,string chainId,string signerId,uint32 nonce,string createdAt,uint32 timeoutSecs,string internal,string external)";
+
+    #[inline]
+    fn struct_hash(&self) -> Hash {
+        Eip712::hash_struct(
+            &Eip712::type_hash(Self::ENCODE_TYPE),
+            [
+                Eip712::encode_bool(self.pay_for_gas),
+                Eip712::encode_bytes(&self.chain_id),
+                Eip712::encode_bytes(&self.signer_id),
+                Eip712::encode_uint(self.nonce),
+                Eip712::encode_bytes(&self.created_at),
+                Eip712::encode_uint(self.timeout_secs),
+                Eip712::encode_bytes(&self.internal),
+                Eip712::encode_bytes(&self.external),
+            ],
+        )
+    }
+}
+
+impl Eip712RequestMessage {
+    /// Returns whether this typed data denotes exactly given [`RequestMessage`],
+    /// i.e. whether the signer authorized this very message.
+    ///
+    /// Members carrying nested structures ([`internal`](Self::internal) and
+    /// [`external`](Self::external)) are compared *semantically*, so their
+    /// JSON formatting doesn't have to be canonical.
+    #[must_use]
+    pub fn matches(&self, msg: &RequestMessage) -> bool {
+        self.pay_for_gas == msg.pay_for_gas
+            && self.chain_id == msg.chain_id
+            && self.signer_id == msg.signer_id.as_str()
+            && self.nonce == msg.nonce
+            && matches_timestamp(&self.created_at, msg.created_at)
+            && matches_timeout(self.timeout_secs, msg.timeout)
+            && serde_json::from_str::<Vec<WalletOp>>(&self.internal)
+                .is_ok_and(|internal| internal == msg.request.internal)
+            && serde_json::from_str::<Vec<NearPromise>>(&self.external)
+                .is_ok_and(|external| external == msg.request.external)
+    }
+}
+
+impl From<&RequestMessage> for Eip712RequestMessage {
+    fn from(msg: &RequestMessage) -> Self {
+        Self {
+            pay_for_gas: msg.pay_for_gas,
+            chain_id: msg.chain_id.clone(),
+            signer_id: msg.signer_id.to_string(),
+            nonce: msg.nonce,
+            created_at: msg.created_at.to_string(),
+            timeout_secs: msg.timeout.as_secs().try_into().unwrap_or(u32::MAX),
+            internal: serde_json::to_string(&msg.request.internal)
+                .unwrap_or_else(|_| unreachable!()),
+            external: serde_json::to_string(&msg.request.external)
+                .unwrap_or_else(|_| unreachable!()),
+        }
+    }
+}
+
+/// Typed data mirroring a NEP-641 [`OffchainMessage`], signed for
+/// [`w_resolve_auth()`](defuse_wallet::offchain::AuthResolver::w_resolve_auth).
+///
+/// ```json
+/// {
+///   "types": {
+///     "EIP712Domain": [
+///       { "name": "name", "type": "string" },
+///       { "name": "version", "type": "string" }
+///     ],
+///     "WalletAuth": [
+///       { "name": "chainId", "type": "string" },
+///       { "name": "signerId", "type": "string" },
+///       { "name": "path", "type": "string[]" },
+///       { "name": "timestamp", "type": "string" },
+///       { "name": "payload", "type": "string" }
+///     ]
+///   },
+///   "primaryType": "WalletAuth",
+///   "domain": { "name": "NEAR Wallet Contract", "version": "1" },
+///   "message": {
+///     "chainId": "mainnet",
+///     "signerId": "0s0000000000000000000000000000000000000000",
+///     "path": ["master.near"],
+///     "timestamp": "1970-01-01T00:00:00Z",
+///     "payload": "Login to example.app at 2026-07-16T00:00:00Z"
+///   }
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Eip712AuthMessage {
+    /// [`OffchainMessage::chain_id`]
+    pub chain_id: String,
+
+    /// [`OffchainMessage::signer_id`]
+    pub signer_id: String,
+
+    /// [`OffchainMessage::path`]: bottom-up path to the top-level resolver,
+    /// i.e. the direct parent first and the top-level resolver last.
+    /// Empty for a top-level authorization.
+    pub path: Vec<String>,
+
+    /// [`OffchainMessage::timestamp`] in RFC-3339 format
+    pub timestamp: String,
+
+    /// [`OffchainMessage::payload`]
+    pub payload: String,
+}
+
+impl Eip712Message for Eip712AuthMessage {
+    const ENCODE_TYPE: &'static str =
+        "WalletAuth(string chainId,string signerId,string[] path,string timestamp,string payload)";
+
+    #[inline]
+    fn struct_hash(&self) -> Hash {
+        Eip712::hash_struct(
+            &Eip712::type_hash(Self::ENCODE_TYPE),
+            [
+                Eip712::encode_bytes(&self.chain_id),
+                Eip712::encode_bytes(&self.signer_id),
+                Eip712::encode_array(self.path.iter().map(Eip712::encode_bytes)),
+                Eip712::encode_bytes(&self.timestamp),
+                Eip712::encode_bytes(&self.payload),
+            ],
+        )
+    }
+}
+
+impl Eip712AuthMessage {
+    /// Returns whether this typed data denotes exactly given [`OffchainMessage`],
+    /// i.e. whether the signer authorized this very message.
+    #[must_use]
+    pub fn matches(&self, msg: &OffchainMessage) -> bool {
+        self.chain_id == msg.chain_id
+            && self.signer_id == msg.signer_id.as_str()
+            && self.path.len() == msg.path.len()
+            && self
+                .path
+                .iter()
+                .zip(&msg.path)
+                .all(|(path, expected)| path == expected.as_str())
+            && matches_timestamp(&self.timestamp, msg.timestamp)
+            && self.payload == msg.payload
+    }
+}
+
+impl From<&OffchainMessage> for Eip712AuthMessage {
+    fn from(msg: &OffchainMessage) -> Self {
+        Self {
+            chain_id: msg.chain_id.clone(),
+            signer_id: msg.signer_id.to_string(),
+            path: msg.path.iter().map(ToString::to_string).collect(),
+            timestamp: msg.timestamp.to_string(),
+            payload: msg.payload.clone(),
+        }
+    }
+}
+
+#[inline]
+fn matches_timestamp(s: &str, timestamp: Timestamp) -> bool {
+    Timestamp::from_str(s).is_ok_and(|parsed| parsed == timestamp)
+}
+
+#[inline]
+fn matches_timeout(secs: u32, timeout: core::time::Duration) -> bool {
+    u64::from(secs) == timeout.as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use hex_literal::hex;
+    use rstest::rstest;
+
+    use super::*;
+
+    /// Known-answer vectors: pin the primary types used on-chain.
+    /// Recomputing them differently is a breaking change to the wire format.
+    #[rstest]
+    #[case(
+        Eip712RequestMessage::ENCODE_TYPE,
+        hex!("1dd8d3b498246adfecef1936d8120de268cc04e0dc5c6a0fe5a3fffd0597e0c8")
+    )]
+    #[case(
+        Eip712AuthMessage::ENCODE_TYPE,
+        hex!("ac4a66d331a12e85c8b62dba6474cc9d52c755fa73733f4e240c8d55275b1ab7")
+    )]
+    fn type_hash(#[case] encode_type: &str, #[case] expected: Hash) {
+        assert_eq!(Eip712::type_hash(encode_type), expected);
+    }
+}

--- a/contracts/wallet/signatures/eip712/src/signer.rs
+++ b/contracts/wallet/signatures/eip712/src/signer.rs
@@ -1,0 +1,81 @@
+use defuse_crypto::{RecoverableSigner, secp256k1::Secp256k1};
+use defuse_wallet::offchain::OffchainMessage;
+use defuse_wallet_sdk::{Proof, RequestMessage, WalletSigner};
+
+use crate::{
+    Eip712AuthMessage, Eip712Message, Eip712RequestMessage, EthAddress, SignedEip712, WalletEip712,
+};
+
+/// Signer wrapper for [`WalletEip712`] signature schema.
+///
+/// It builds the same typed data an Ethereum wallet would be asked to sign
+/// via `eth_signTypedData_v4` and signs its
+/// [prehash](Eip712Message::prehash).
+///
+/// # Examples
+///
+/// ```rust
+/// use defuse_wallet_eip712::{WalletEip712, WalletEip712Signer, crypto::secp256k1::k256};
+/// use defuse_wallet_sdk::{Request, SignatureSchema, Wallet};
+/// # use defuse_wallet_sdk::GlobalContractId;
+/// # use hex_literal::hex;
+/// use k256::elliptic_curve::Generate;
+/// # const GLOBAL_CONTRACT_ID: GlobalContractId = GlobalContractId::CodeHash(
+/// #     hex!("0000000000000000000000000000000000000000000000000000000000000000"),
+/// # );
+///
+/// # tokio_test::block_on(async {
+/// let signer = k256::ecdsa::SigningKey::generate();
+/// let wallet = Wallet::<WalletEip712>::new(
+///     GLOBAL_CONTRACT_ID,
+///     WalletEip712Signer(signer),
+/// );
+///
+/// let (msg, proof) = wallet.sign(Request::new()).await?;
+///
+/// assert!(
+///     WalletEip712::verify_request_msg(&wallet.public_key(), &msg, &proof),
+///     "signer produced invalid signature",
+/// );
+/// # Ok::<_, Box<dyn core::error::Error>>(()) }).unwrap();
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, derive_more::From, derive_more::AsRef)]
+pub struct WalletEip712Signer<S>(pub S);
+
+impl<S> WalletEip712Signer<S>
+where
+    S: RecoverableSigner<Secp256k1>,
+{
+    async fn sign_typed_data<M>(&self, message: M) -> Result<Proof, S::Error>
+    where
+        M: Eip712Message + ::serde::Serialize,
+    {
+        let signature = self.0.sign_recoverable(&message.prehash()).await?;
+
+        Ok(serde_json::to_string(&SignedEip712 {
+            message,
+            signature: signature.into(),
+        })
+        .unwrap_or_else(|_| unreachable!()))
+    }
+}
+
+impl<S> WalletSigner<WalletEip712> for WalletEip712Signer<S>
+where
+    S: RecoverableSigner<Secp256k1>,
+{
+    type Error = S::Error;
+
+    #[inline]
+    fn public_key(&self) -> EthAddress {
+        EthAddress::from(&self.0.public_key())
+    }
+
+    async fn sign_request_msg(&self, msg: &RequestMessage) -> Result<Proof, Self::Error> {
+        self.sign_typed_data(Eip712RequestMessage::from(msg)).await
+    }
+
+    async fn sign_offchain_msg(&self, msg: &OffchainMessage) -> Result<Proof, Self::Error> {
+        self.sign_typed_data(Eip712AuthMessage::from(msg)).await
+    }
+}

--- a/contracts/wallet/signatures/eip712/tests/fixtures.rs
+++ b/contracts/wallet/signatures/eip712/tests/fixtures.rs
@@ -1,0 +1,116 @@
+//! Shared EIP-712 wallet-contract test vectors.
+//!
+//! The fixture file is meant to be consumed by clients implementing the
+//! `eth_signTypedData_v4` flow as well, to lock the exact typed data and
+//! proof format across implementations. Any change to these vectors is a
+//! breaking change to the wire format of the `wallet-eip712` contract
+//! variant.
+
+use std::str::FromStr;
+
+use defuse_wallet::{RequestMessage, SignatureSchema, offchain::OffchainMessage};
+use defuse_wallet_eip712::{
+    DOMAIN, Eip712AuthMessage, Eip712Message, Eip712RequestMessage, EthAddress, WalletEip712,
+};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Fixtures {
+    #[serde(with = "hex::serde")]
+    domain_separator: [u8; 32],
+    domain: Domain,
+    address: String,
+    request_vectors: Vec<Vector<RequestMessage, Eip712RequestMessage>>,
+    auth_vectors: Vec<Vector<OffchainMessage, Eip712AuthMessage>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Domain {
+    name: String,
+    version: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct Vector<M, T> {
+    name: String,
+    /// The canonical message the contract acts upon.
+    message: M,
+    /// The `message` of the `eth_signTypedData_v4` request.
+    typed_message: T,
+    /// The digest signed by the Ethereum wallet.
+    #[serde(with = "hex::serde")]
+    prehash: [u8; 32],
+    /// The `proof` submitted on-chain.
+    proof: serde_json::Value,
+}
+
+#[test]
+fn eip712_wallet_message_vectors() {
+    let Fixtures {
+        domain_separator,
+        domain,
+        address,
+        request_vectors,
+        auth_vectors,
+    } = serde_json::from_str(include_str!("fixtures/eip712-wallet-message.json"))
+        .expect("fixtures must deserialize");
+
+    assert_eq!(domain.name, DOMAIN.name);
+    assert_eq!(domain.version, DOMAIN.version);
+    assert_eq!(DOMAIN.separator(), domain_separator);
+
+    let address = EthAddress::from_str(&address).unwrap();
+
+    assert!(!request_vectors.is_empty());
+    assert!(!auth_vectors.is_empty());
+
+    for Vector {
+        name,
+        message,
+        typed_message,
+        prehash,
+        proof,
+    } in request_vectors
+    {
+        assert_eq!(
+            Eip712RequestMessage::from(&message),
+            typed_message,
+            "typed data mismatch for vector '{name}'",
+        );
+        assert_eq!(
+            typed_message.prehash(),
+            prehash,
+            "prehash mismatch for vector '{name}': got {}",
+            hex::encode(typed_message.prehash()),
+        );
+        assert!(
+            WalletEip712::verify_request_msg(&address, &message, &proof.to_string()),
+            "proof of vector '{name}' didn't pass verification",
+        );
+    }
+
+    for Vector {
+        name,
+        message,
+        typed_message,
+        prehash,
+        proof,
+    } in auth_vectors
+    {
+        assert_eq!(
+            Eip712AuthMessage::from(&message),
+            typed_message,
+            "typed data mismatch for vector '{name}'",
+        );
+        assert_eq!(
+            typed_message.prehash(),
+            prehash,
+            "prehash mismatch for vector '{name}': got {}",
+            hex::encode(typed_message.prehash()),
+        );
+        assert!(
+            WalletEip712::verify_offchain_msg(&address, &message, &proof.to_string()),
+            "proof of vector '{name}' didn't pass verification",
+        );
+    }
+}

--- a/contracts/wallet/signatures/eip712/tests/fixtures/eip712-wallet-message.json
+++ b/contracts/wallet/signatures/eip712/tests/fixtures/eip712-wallet-message.json
@@ -1,5 +1,5 @@
 {
-  "comment": "Shared EIP-712 wallet-contract test vectors. Consumed by this crate's tests AND meant to be consumed by any client implementing the `eth_signTypedData_v4` flow — keep the copies in sync. Any change here is a breaking change to the wire format of the `wallet-eip712` contract variant. `typed_message` is the `message` of the `eth_signTypedData_v4` request (primary type `WalletRequest`/`WalletAuth`), `prehash` is keccak256(0x1901 || domainSeparator || hashStruct(typed_message)), i.e. what the Ethereum wallet signs, and `proof` is what gets submitted on-chain (`signature` is the 65-byte r||s||v signature with v normalized from 27/28 to 0/1). The contract stores the signer's Ethereum `address` (not its public key), which it derives from the public key recovered from the proof. All vectors are signed by the test key 0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318 and cross-checked against `ethers.TypedDataEncoder.hash()` / `ethers.Wallet.signTypedData()`.",
+  "comment": "Shared EIP-712 wallet-contract test vectors. Consumed by this crate's tests AND meant to be consumed by any client implementing the `eth_signTypedData_v4` flow \u2014 keep the copies in sync. Any change here is a breaking change to the wire format of the `wallet-eip712` contract variant. `typed_message` is the `message` of the `eth_signTypedData_v4` request (primary type `WalletRequest`/`WalletAuth`), `prehash` is keccak256(0x1901 || domainSeparator || hashStruct(typed_message)), i.e. what the Ethereum wallet signs, and `proof` is what gets submitted on-chain (`signature` is the 65-byte r||s||v signature with v normalized from 27/28 to 0/1). Request contents are unpacked into typed structures (WalletOp[]/NearPromise[]/NearAction[]); only leaf `payload`s remain JSON strings, compared semantically on-chain (whitespace/key order free, extra fields rejected). `payForGas` MAY be omitted from the JSON (defaults to false), but is always part of the signed type. The contract stores the signer's Ethereum `address` (not its public key), which it derives from the public key recovered from the proof. All vectors are signed by the test key 0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318 and cross-checked against `ethers.TypedDataEncoder.hash()` / `ethers.Wallet.signTypedData()`.",
   "domain": {
     "name": "NEAR Wallet Contract",
     "version": "1"
@@ -17,10 +17,6 @@
       }
     ],
     "WalletRequest": [
-      {
-        "name": "payForGas",
-        "type": "bool"
-      },
       {
         "name": "chainId",
         "type": "string"
@@ -43,11 +39,15 @@
       },
       {
         "name": "internal",
-        "type": "string"
+        "type": "WalletOp[]"
       },
       {
         "name": "external",
-        "type": "string"
+        "type": "NearPromise[]"
+      },
+      {
+        "name": "payForGas",
+        "type": "bool"
       }
     ],
     "WalletAuth": [
@@ -71,6 +71,40 @@
         "name": "payload",
         "type": "string"
       }
+    ],
+    "WalletOp": [
+      {
+        "name": "op",
+        "type": "string"
+      },
+      {
+        "name": "payload",
+        "type": "string"
+      }
+    ],
+    "NearPromise": [
+      {
+        "name": "receiverId",
+        "type": "string"
+      },
+      {
+        "name": "refundTo",
+        "type": "string"
+      },
+      {
+        "name": "actions",
+        "type": "NearAction[]"
+      }
+    ],
+    "NearAction": [
+      {
+        "name": "action",
+        "type": "string"
+      },
+      {
+        "name": "payload",
+        "type": "string"
+      }
     ]
   },
   "address": "0x2c7536e3605d9c16a7a3d7b1898e529396a65c23",
@@ -86,28 +120,28 @@
         "request": {}
       },
       "typed_message": {
-        "payForGas": false,
         "chainId": "mainnet",
         "signerId": "0s0000000000000000000000000000000000000000",
         "nonce": 0,
         "createdAt": "1970-01-01T00:00:00Z",
         "timeoutSecs": 3600,
-        "internal": "[]",
-        "external": "[]"
+        "internal": [],
+        "external": [],
+        "payForGas": false
       },
-      "prehash": "8ccffe6835c7b5250eb7f468d94ec249125b14b1242932b3ff223d6154789ed5",
+      "prehash": "6224b1d68b462c40466309e477e631168b6bbb2b2f0b19d57f3552a83eec9f8e",
       "proof": {
         "message": {
-          "payForGas": false,
           "chainId": "mainnet",
           "signerId": "0s0000000000000000000000000000000000000000",
           "nonce": 0,
           "createdAt": "1970-01-01T00:00:00Z",
           "timeoutSecs": 3600,
-          "internal": "[]",
-          "external": "[]"
+          "internal": [],
+          "external": [],
+          "payForGas": false
         },
-        "signature": "secp256k1:4pzrgEmzg3H8G9mARPQd9vfoVv8n71jCYHUMGCiasxFReQCEax9kiFKp4xe32k2kFWjghps3jqUxznCSYbmZfsjkj"
+        "signature": "secp256k1:JxeyKEAHxW8pPas5JU3kSRRN6GXU2xVjCUXbrELgNZhtcPGbJi9Fnm3khCT3qteMzbUEGnXutFq84c8AsnaKDZag"
       }
     },
     {
@@ -130,28 +164,38 @@
         }
       },
       "typed_message": {
-        "payForGas": false,
         "chainId": "mainnet",
         "signerId": "0se5eba21e8f191e1880e453794bc551dfa50a3419",
         "nonce": 42,
         "createdAt": "2026-07-16T12:34:56.789Z",
         "timeoutSecs": 300,
-        "internal": "[{\"op\":\"add_extension\",\"payload\":{\"account_id\":\"extension.near\"}}]",
-        "external": "[]"
+        "internal": [
+          {
+            "op": "add_extension",
+            "payload": "{\"account_id\":\"extension.near\"}"
+          }
+        ],
+        "external": [],
+        "payForGas": false
       },
-      "prehash": "61136939ea1a1a2423876a51b2ed141e1e9fcd1b7757d3d8a800721971c22195",
+      "prehash": "dedc874daf7e7c52e8b3a48c1b1113eeeb9a3501f77bf880c316b45d4228fe70",
       "proof": {
         "message": {
-          "payForGas": false,
           "chainId": "mainnet",
           "signerId": "0se5eba21e8f191e1880e453794bc551dfa50a3419",
           "nonce": 42,
           "createdAt": "2026-07-16T12:34:56.789Z",
           "timeoutSecs": 300,
-          "internal": "[{\"op\":\"add_extension\",\"payload\":{\"account_id\":\"extension.near\"}}]",
-          "external": "[]"
+          "internal": [
+            {
+              "op": "add_extension",
+              "payload": "{\"account_id\":\"extension.near\"}"
+            }
+          ],
+          "external": [],
+          "payForGas": false
         },
-        "signature": "secp256k1:Lw6tXt7E2zw8pEmVb6ANoNHFa4cJaJsCq5D7XcQ1KKvchQvNYQDpUnRjmUxCWsFiXktngrFyjEKd3U5pRymnSi5V2"
+        "signature": "secp256k1:AzmTJjs5DpGm13uQcTp6buT8nuHApVHBovUCAA1YbpmdmPMrdi4GnrMmzWtD938Vokw3yrQNANocyfCbydgfWy5LL"
       }
     },
     {
@@ -166,28 +210,134 @@
         "request": {}
       },
       "typed_message": {
-        "payForGas": true,
         "chainId": "mainnet",
         "signerId": "0se5eba21e8f191e1880e453794bc551dfa50a3419",
         "nonce": 43,
         "createdAt": "2026-07-16T12:34:56.789Z",
         "timeoutSecs": 300,
-        "internal": "[]",
-        "external": "[]"
+        "internal": [],
+        "external": [],
+        "payForGas": true
       },
-      "prehash": "eab9b1201cc52ed3ff3296676cfb5679c36fd39cc4fdc4479c4d8efbc64f91e6",
+      "prehash": "1ca4ad72c5012ce31cab931b5ec2792fd5220e0064ebce98a85be2be3fb0e3d5",
       "proof": {
         "message": {
-          "payForGas": true,
           "chainId": "mainnet",
           "signerId": "0se5eba21e8f191e1880e453794bc551dfa50a3419",
           "nonce": 43,
           "createdAt": "2026-07-16T12:34:56.789Z",
           "timeoutSecs": 300,
-          "internal": "[]",
-          "external": "[]"
+          "internal": [],
+          "external": [],
+          "payForGas": true
         },
-        "signature": "secp256k1:FvUUZi8PepvBNcjKxZbdqWBtEWh4ueM2Vb2SmLCQFASNwpgDFmVhqYak8e87ZKWKJEY6pUgc33bGjCvLCyNLtJidW"
+        "signature": "secp256k1:3Pt5uLs3YNC8wTJ8r8wCQT6bGE3CpEm9XVRL3ZaD2Lg2Xpz1cNZoTfBejoqGziGCddp4pPhk94RdCNXtDJ6PEWiBZ"
+      }
+    },
+    {
+      "name": "promises",
+      "message": {
+        "chain_id": "mainnet",
+        "signer_id": "0se5eba21e8f191e1880e453794bc551dfa50a3419",
+        "nonce": 44,
+        "created_at": "2026-07-16T12:34:56.789Z",
+        "timeout_secs": 300,
+        "request": {
+          "external": [
+            {
+              "receiver_id": "v1.signer",
+              "actions": [
+                {
+                  "action": "function_call",
+                  "payload": {
+                    "function_name": "sign",
+                    "args": "eyJyZXF1ZXN0Ijp7ImRvbWFpbl9pZCI6MCwicGF0aCI6IiJ9fQ==",
+                    "deposit": "1",
+                    "gas": "30000000000000"
+                  }
+                }
+              ]
+            },
+            {
+              "receiver_id": "bob.near",
+              "refund_to": "alice.near",
+              "actions": [
+                {
+                  "action": "transfer",
+                  "payload": {
+                    "amount": "1000000000000000000000000"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "typed_message": {
+        "chainId": "mainnet",
+        "signerId": "0se5eba21e8f191e1880e453794bc551dfa50a3419",
+        "nonce": 44,
+        "createdAt": "2026-07-16T12:34:56.789Z",
+        "timeoutSecs": 300,
+        "internal": [],
+        "external": [
+          {
+            "receiverId": "v1.signer",
+            "refundTo": "",
+            "actions": [
+              {
+                "action": "function_call",
+                "payload": "{\"function_name\":\"sign\",\"args\":\"eyJyZXF1ZXN0Ijp7ImRvbWFpbl9pZCI6MCwicGF0aCI6IiJ9fQ==\",\"deposit\":\"1\",\"gas\":\"30000000000000\"}"
+              }
+            ]
+          },
+          {
+            "receiverId": "bob.near",
+            "refundTo": "alice.near",
+            "actions": [
+              {
+                "action": "transfer",
+                "payload": "{\"amount\":\"1000000000000000000000000\"}"
+              }
+            ]
+          }
+        ],
+        "payForGas": false
+      },
+      "prehash": "b5f469deb3e63c6d251679be7c78dfb7112c57f049c90e5ca6a695d3e30bc09f",
+      "proof": {
+        "message": {
+          "chainId": "mainnet",
+          "signerId": "0se5eba21e8f191e1880e453794bc551dfa50a3419",
+          "nonce": 44,
+          "createdAt": "2026-07-16T12:34:56.789Z",
+          "timeoutSecs": 300,
+          "internal": [],
+          "external": [
+            {
+              "receiverId": "v1.signer",
+              "refundTo": "",
+              "actions": [
+                {
+                  "action": "function_call",
+                  "payload": "{\"function_name\":\"sign\",\"args\":\"eyJyZXF1ZXN0Ijp7ImRvbWFpbl9pZCI6MCwicGF0aCI6IiJ9fQ==\",\"deposit\":\"1\",\"gas\":\"30000000000000\"}"
+                }
+              ]
+            },
+            {
+              "receiverId": "bob.near",
+              "refundTo": "alice.near",
+              "actions": [
+                {
+                  "action": "transfer",
+                  "payload": "{\"amount\":\"1000000000000000000000000\"}"
+                }
+              ]
+            }
+          ],
+          "payForGas": false
+        },
+        "signature": "secp256k1:7UCi7NAYaeSSyoE5KL5LeZP9DenJ6WEodw6CCZKJj3TeDnmLZgbiX3Y4ZLBHWrh68YS4DvviG3H1DAU1dmN4F47S8"
       }
     }
   ],

--- a/contracts/wallet/signatures/eip712/tests/fixtures/eip712-wallet-message.json
+++ b/contracts/wallet/signatures/eip712/tests/fixtures/eip712-wallet-message.json
@@ -1,0 +1,287 @@
+{
+  "comment": "Shared EIP-712 wallet-contract test vectors. Consumed by this crate's tests AND meant to be consumed by any client implementing the `eth_signTypedData_v4` flow — keep the copies in sync. Any change here is a breaking change to the wire format of the `wallet-eip712` contract variant. `typed_message` is the `message` of the `eth_signTypedData_v4` request (primary type `WalletRequest`/`WalletAuth`), `prehash` is keccak256(0x1901 || domainSeparator || hashStruct(typed_message)), i.e. what the Ethereum wallet signs, and `proof` is what gets submitted on-chain (`signature` is the 65-byte r||s||v signature with v normalized from 27/28 to 0/1). The contract stores the signer's Ethereum `address` (not its public key), which it derives from the public key recovered from the proof. All vectors are signed by the test key 0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318 and cross-checked against `ethers.TypedDataEncoder.hash()` / `ethers.Wallet.signTypedData()`.",
+  "domain": {
+    "name": "NEAR Wallet Contract",
+    "version": "1"
+  },
+  "domain_separator": "9ed0384a9369f42aa89e172b67359e73238fce303b45b92842e471874e2f6d22",
+  "types": {
+    "EIP712Domain": [
+      {
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "name": "version",
+        "type": "string"
+      }
+    ],
+    "WalletRequest": [
+      {
+        "name": "payForGas",
+        "type": "bool"
+      },
+      {
+        "name": "chainId",
+        "type": "string"
+      },
+      {
+        "name": "signerId",
+        "type": "string"
+      },
+      {
+        "name": "nonce",
+        "type": "uint32"
+      },
+      {
+        "name": "createdAt",
+        "type": "string"
+      },
+      {
+        "name": "timeoutSecs",
+        "type": "uint32"
+      },
+      {
+        "name": "internal",
+        "type": "string"
+      },
+      {
+        "name": "external",
+        "type": "string"
+      }
+    ],
+    "WalletAuth": [
+      {
+        "name": "chainId",
+        "type": "string"
+      },
+      {
+        "name": "signerId",
+        "type": "string"
+      },
+      {
+        "name": "path",
+        "type": "string[]"
+      },
+      {
+        "name": "timestamp",
+        "type": "string"
+      },
+      {
+        "name": "payload",
+        "type": "string"
+      }
+    ]
+  },
+  "address": "0x2c7536e3605d9c16a7a3d7b1898e529396a65c23",
+  "request_vectors": [
+    {
+      "name": "empty_request",
+      "message": {
+        "chain_id": "mainnet",
+        "signer_id": "0s0000000000000000000000000000000000000000",
+        "nonce": 0,
+        "created_at": "1970-01-01T00:00:00Z",
+        "timeout_secs": 3600,
+        "request": {}
+      },
+      "typed_message": {
+        "payForGas": false,
+        "chainId": "mainnet",
+        "signerId": "0s0000000000000000000000000000000000000000",
+        "nonce": 0,
+        "createdAt": "1970-01-01T00:00:00Z",
+        "timeoutSecs": 3600,
+        "internal": "[]",
+        "external": "[]"
+      },
+      "prehash": "8ccffe6835c7b5250eb7f468d94ec249125b14b1242932b3ff223d6154789ed5",
+      "proof": {
+        "message": {
+          "payForGas": false,
+          "chainId": "mainnet",
+          "signerId": "0s0000000000000000000000000000000000000000",
+          "nonce": 0,
+          "createdAt": "1970-01-01T00:00:00Z",
+          "timeoutSecs": 3600,
+          "internal": "[]",
+          "external": "[]"
+        },
+        "signature": "secp256k1:4pzrgEmzg3H8G9mARPQd9vfoVv8n71jCYHUMGCiasxFReQCEax9kiFKp4xe32k2kFWjghps3jqUxznCSYbmZfsjkj"
+      }
+    },
+    {
+      "name": "add_extension",
+      "message": {
+        "chain_id": "mainnet",
+        "signer_id": "0se5eba21e8f191e1880e453794bc551dfa50a3419",
+        "nonce": 42,
+        "created_at": "2026-07-16T12:34:56.789Z",
+        "timeout_secs": 300,
+        "request": {
+          "internal": [
+            {
+              "op": "add_extension",
+              "payload": {
+                "account_id": "extension.near"
+              }
+            }
+          ]
+        }
+      },
+      "typed_message": {
+        "payForGas": false,
+        "chainId": "mainnet",
+        "signerId": "0se5eba21e8f191e1880e453794bc551dfa50a3419",
+        "nonce": 42,
+        "createdAt": "2026-07-16T12:34:56.789Z",
+        "timeoutSecs": 300,
+        "internal": "[{\"op\":\"add_extension\",\"payload\":{\"account_id\":\"extension.near\"}}]",
+        "external": "[]"
+      },
+      "prehash": "61136939ea1a1a2423876a51b2ed141e1e9fcd1b7757d3d8a800721971c22195",
+      "proof": {
+        "message": {
+          "payForGas": false,
+          "chainId": "mainnet",
+          "signerId": "0se5eba21e8f191e1880e453794bc551dfa50a3419",
+          "nonce": 42,
+          "createdAt": "2026-07-16T12:34:56.789Z",
+          "timeoutSecs": 300,
+          "internal": "[{\"op\":\"add_extension\",\"payload\":{\"account_id\":\"extension.near\"}}]",
+          "external": "[]"
+        },
+        "signature": "secp256k1:Lw6tXt7E2zw8pEmVb6ANoNHFa4cJaJsCq5D7XcQ1KKvchQvNYQDpUnRjmUxCWsFiXktngrFyjEKd3U5pRymnSi5V2"
+      }
+    },
+    {
+      "name": "pay_for_gas",
+      "message": {
+        "pay_for_gas": true,
+        "chain_id": "mainnet",
+        "signer_id": "0se5eba21e8f191e1880e453794bc551dfa50a3419",
+        "nonce": 43,
+        "created_at": "2026-07-16T12:34:56.789Z",
+        "timeout_secs": 300,
+        "request": {}
+      },
+      "typed_message": {
+        "payForGas": true,
+        "chainId": "mainnet",
+        "signerId": "0se5eba21e8f191e1880e453794bc551dfa50a3419",
+        "nonce": 43,
+        "createdAt": "2026-07-16T12:34:56.789Z",
+        "timeoutSecs": 300,
+        "internal": "[]",
+        "external": "[]"
+      },
+      "prehash": "eab9b1201cc52ed3ff3296676cfb5679c36fd39cc4fdc4479c4d8efbc64f91e6",
+      "proof": {
+        "message": {
+          "payForGas": true,
+          "chainId": "mainnet",
+          "signerId": "0se5eba21e8f191e1880e453794bc551dfa50a3419",
+          "nonce": 43,
+          "createdAt": "2026-07-16T12:34:56.789Z",
+          "timeoutSecs": 300,
+          "internal": "[]",
+          "external": "[]"
+        },
+        "signature": "secp256k1:FvUUZi8PepvBNcjKxZbdqWBtEWh4ueM2Vb2SmLCQFASNwpgDFmVhqYak8e87ZKWKJEY6pUgc33bGjCvLCyNLtJidW"
+      }
+    }
+  ],
+  "auth_vectors": [
+    {
+      "name": "top_level",
+      "message": {
+        "chain_id": "mainnet",
+        "signer_id": "0se5eba21e8f191e1880e453794bc551dfa50a3419",
+        "timestamp": "1970-01-01T00:00:00Z",
+        "payload": "Login to example.app at 2026-07-16T00:00:00Z"
+      },
+      "typed_message": {
+        "chainId": "mainnet",
+        "signerId": "0se5eba21e8f191e1880e453794bc551dfa50a3419",
+        "path": [],
+        "timestamp": "1970-01-01T00:00:00Z",
+        "payload": "Login to example.app at 2026-07-16T00:00:00Z"
+      },
+      "prehash": "280bc97ecca0012455c93038999a2273adf242f444c1e0e21fcc0dee3f35e68c",
+      "proof": {
+        "message": {
+          "chainId": "mainnet",
+          "signerId": "0se5eba21e8f191e1880e453794bc551dfa50a3419",
+          "path": [],
+          "timestamp": "1970-01-01T00:00:00Z",
+          "payload": "Login to example.app at 2026-07-16T00:00:00Z"
+        },
+        "signature": "secp256k1:AhkHT4uzDC2R8XDZ7xwsn11DAG9Hvird9jkqmHvsXUxkVahXBvQKsjesco9mbvr7b8VGjHbsNhbit33rmiiA6Dqjm"
+      }
+    },
+    {
+      "name": "json_payload",
+      "message": {
+        "chain_id": "mainnet",
+        "signer_id": "0se5eba21e8f191e1880e453794bc551dfa50a3419",
+        "timestamp": "2026-07-16T12:34:56.789Z",
+        "payload": "{\n  \"domain\": \"Near MPC\",\n  \"action\": \"sign\",\n  \"msg\": \"Hello, Near!\"\n}"
+      },
+      "typed_message": {
+        "chainId": "mainnet",
+        "signerId": "0se5eba21e8f191e1880e453794bc551dfa50a3419",
+        "path": [],
+        "timestamp": "2026-07-16T12:34:56.789Z",
+        "payload": "{\n  \"domain\": \"Near MPC\",\n  \"action\": \"sign\",\n  \"msg\": \"Hello, Near!\"\n}"
+      },
+      "prehash": "9dddc1138110ef1653af48cae5a5c1eed2f1be890519ef8a3be4407508197b65",
+      "proof": {
+        "message": {
+          "chainId": "mainnet",
+          "signerId": "0se5eba21e8f191e1880e453794bc551dfa50a3419",
+          "path": [],
+          "timestamp": "2026-07-16T12:34:56.789Z",
+          "payload": "{\n  \"domain\": \"Near MPC\",\n  \"action\": \"sign\",\n  \"msg\": \"Hello, Near!\"\n}"
+        },
+        "signature": "secp256k1:ASwTgdT4BsGRTEqMtSCYr6mHgSwWaYCZkzdqhJ7wpNw5ZFfqQqHt6V3yy4JeWBsgb7KedhHrxY2VyHD8NHvCg4Kwu"
+      }
+    },
+    {
+      "name": "delegated_path",
+      "message": {
+        "chain_id": "mainnet",
+        "signer_id": "0se5eba21e8f191e1880e453794bc551dfa50a3419",
+        "path": [
+          "master.near",
+          "v1.signer"
+        ],
+        "timestamp": "2026-07-16T12:34:56.789Z",
+        "payload": "withdraw 100 USDC to bob.near"
+      },
+      "typed_message": {
+        "chainId": "mainnet",
+        "signerId": "0se5eba21e8f191e1880e453794bc551dfa50a3419",
+        "path": [
+          "master.near",
+          "v1.signer"
+        ],
+        "timestamp": "2026-07-16T12:34:56.789Z",
+        "payload": "withdraw 100 USDC to bob.near"
+      },
+      "prehash": "d691f037067d14f04334b099811c164542d49c625465622afd7f9a335a9998cf",
+      "proof": {
+        "message": {
+          "chainId": "mainnet",
+          "signerId": "0se5eba21e8f191e1880e453794bc551dfa50a3419",
+          "path": [
+            "master.near",
+            "v1.signer"
+          ],
+          "timestamp": "2026-07-16T12:34:56.789Z",
+          "payload": "withdraw 100 USDC to bob.near"
+        },
+        "signature": "secp256k1:9iKWoMUxN6bHqrttUNyb7SUAiBzGtM88TpNCg2TzqkYn12ThEKkdX8zy9R1KD13Bhzqa1EzeSeS1yFdda2rT1vTJw"
+      }
+    }
+  ]
+}

--- a/crates/signatures/eip712/Cargo.toml
+++ b/crates/signatures/eip712/Cargo.toml
@@ -1,0 +1,20 @@
+lints.workspace = true
+
+[package]
+name = "defuse-eip712"
+edition.workspace = true
+version.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+
+[dependencies]
+defuse-crypto = { workspace = true, features = ["secp256k1"] }
+defuse-digest = { workspace = true, features = ["sha3"] }
+
+[dev-dependencies]
+defuse-crypto = { workspace = true, features = ["fmt", "signing"] }
+
+hex-literal.workspace = true
+k256 = { workspace = true, features = ["getrandom"] }
+rstest.workspace = true
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/signatures/eip712/src/lib.rs
+++ b/crates/signatures/eip712/src/lib.rs
@@ -1,0 +1,244 @@
+//! [EIP-712](https://eips.ethereum.org/EIPS/eip-712) Typed structured data
+//! hashing and signing.
+//!
+//! Ethereum wallets (e.g. `MetaMask`, `WalletConnect`) expose this standard as
+//! `eth_signTypedData_v4`: instead of signing an opaque byte string (as with
+//! [ERC-191](https://eips.ethereum.org/EIPS/eip-191)), the user signs a
+//! *typed* structure bound to a *domain*, which the wallet displays in a
+//! structured form and which cannot be replayed in another domain.
+//!
+//! This crate provides the hashing primitives only: callers define their own
+//! type strings and encode struct members into 32-byte words themselves.
+
+use defuse_crypto::{Curve, RecoverableCurve, secp256k1::Secp256k1};
+use defuse_digest::{Digest, sha3::Keccak256};
+
+/// `keccak256` output, i.e. a 32-byte hash
+pub type Hash = [u8; 32];
+
+/// [EIP-712](https://eips.ethereum.org/EIPS/eip-712) Typed structured data
+/// hashing and signing
+pub struct Eip712;
+
+impl Eip712 {
+    /// `typeHash = keccak256(encodeType(typeOf(s)))`, where `encodeType` is
+    /// the canonical type string, e.g.
+    /// `"WalletMessage(bytes32 hash)"`.
+    #[inline]
+    pub fn type_hash(encode_type: impl AsRef<[u8]>) -> Hash {
+        Keccak256::digest(encode_type).into()
+    }
+
+    /// `hashStruct(s) = keccak256(typeHash ‖ encodeData(s))`, where
+    /// `encodeData(s)` is the concatenation of struct members, each already
+    /// [encoded](Self::encode_bytes) into a single 32-byte word.
+    #[inline]
+    pub fn hash_struct(type_hash: &Hash, encode_data: impl IntoIterator<Item = Hash>) -> Hash {
+        encode_data
+            .into_iter()
+            .fold(Keccak256::new_with_prefix(type_hash), Digest::chain_update)
+            .finalize()
+            .into()
+    }
+
+    /// `encodeData` for dynamic members (i.e. `string` and `bytes`), which
+    /// are encoded as `keccak256` of their contents.
+    ///
+    /// Atomic members of exactly 32 bytes (e.g. `bytes32`) are encoded
+    /// directly as-is.
+    #[inline]
+    pub fn encode_bytes(value: impl AsRef<[u8]>) -> Hash {
+        Keccak256::digest(value).into()
+    }
+
+    /// `encodeData` for unsigned integer members (i.e. `uintN`), which are
+    /// encoded as their big-endian representation, left-padded with zeroes
+    /// to 32 bytes.
+    #[inline]
+    pub fn encode_uint(value: impl Into<u128>) -> Hash {
+        let mut buf = [0u8; 32];
+        buf[16..].copy_from_slice(&value.into().to_be_bytes());
+        buf
+    }
+
+    /// `encodeData` for `bool` members, which are encoded as `uint256`
+    /// `0`/`1`.
+    #[inline]
+    pub fn encode_bool(value: bool) -> Hash {
+        Self::encode_uint(u8::from(value))
+    }
+
+    /// `encodeData` for array members (e.g. `string[]`), which are encoded
+    /// as `keccak256` of the concatenation of their contents, each already
+    /// [encoded](Self::encode_bytes) into a single 32-byte word.
+    #[inline]
+    pub fn encode_array(items: impl IntoIterator<Item = Hash>) -> Hash {
+        items
+            .into_iter()
+            .fold(Keccak256::new(), Digest::chain_update)
+            .finalize()
+            .into()
+    }
+
+    /// Derive prehash for signing according to following schema:
+    ///
+    /// ```text
+    /// keccak256(0x19 ‖ 0x01 ‖ domainSeparator ‖ hashStruct(message))
+    /// ```
+    #[inline]
+    pub fn prehash(domain_separator: &Hash, struct_hash: &Hash) -> Hash {
+        Keccak256::new_with_prefix(b"\x19\x01")
+            .chain_update(domain_separator)
+            .chain_update(struct_hash)
+            .finalize()
+            .into()
+    }
+
+    /// Try to recover public key which signed given message according to
+    /// [EIP-712](https://eips.ethereum.org/EIPS/eip-712) and produced given
+    /// signature and recovery id.
+    #[must_use = "check recovered public key"]
+    #[inline]
+    pub fn recover(
+        domain_separator: &Hash,
+        struct_hash: &Hash,
+        signature: &<Secp256k1 as Curve>::Signature,
+        recovery_id: <Secp256k1 as RecoverableCurve>::RecoveryId,
+    ) -> Option<<Secp256k1 as Curve>::PublicKey> {
+        Secp256k1::recover(
+            &Self::prehash(domain_separator, struct_hash),
+            signature,
+            recovery_id,
+        )
+    }
+}
+
+/// [EIP-712](https://eips.ethereum.org/EIPS/eip-712) domain with `name` and
+/// `version` members only.
+///
+/// `chainId` and `verifyingContract` are intentionally omitted: NEAR contracts
+/// have no EVM chain id and their account ids do not fit into `address`. The
+/// signed message itself is expected to bind the network and the contract
+/// instance instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Eip712Domain<'a> {
+    /// `EIP712Domain.name`
+    pub name: &'a str,
+    /// `EIP712Domain.version`
+    pub version: &'a str,
+}
+
+impl Eip712Domain<'_> {
+    /// `encodeType(EIP712Domain)`
+    pub const ENCODE_TYPE: &'static str = "EIP712Domain(string name,string version)";
+
+    /// `domainSeparator = hashStruct(eip712Domain)`
+    #[inline]
+    pub fn separator(&self) -> Hash {
+        Eip712::hash_struct(
+            &Eip712::type_hash(Self::ENCODE_TYPE),
+            [
+                Eip712::encode_bytes(self.name),
+                Eip712::encode_bytes(self.version),
+            ],
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use defuse_crypto::RecoverableSigner;
+    use hex_literal::hex;
+    use k256::{ecdsa::SigningKey, elliptic_curve::Generate};
+    use rstest::rstest;
+
+    use super::*;
+
+    const DOMAIN: Eip712Domain<'static> = Eip712Domain {
+        name: "NEAR Wallet Contract",
+        version: "1",
+    };
+
+    const MAIL_TYPE: &str = "Mail(string contents)";
+
+    #[rstest]
+    fn domain_separator() {
+        // known-answer vector: `ethers.TypedDataEncoder.hashDomain({
+        //   name: "NEAR Wallet Contract", version: "1" })`
+        assert_eq!(
+            DOMAIN.separator(),
+            hex!("9ed0384a9369f42aa89e172b67359e73238fce303b45b92842e471874e2f6d22"),
+        );
+    }
+
+    #[rstest]
+    #[case(0u32, hex!("0000000000000000000000000000000000000000000000000000000000000000"))]
+    #[case(
+        42u32,
+        hex!("000000000000000000000000000000000000000000000000000000000000002a")
+    )]
+    #[case(
+        u32::MAX,
+        hex!("00000000000000000000000000000000000000000000000000000000ffffffff")
+    )]
+    fn encode_uint(#[case] value: u32, #[case] encoded: Hash) {
+        assert_eq!(Eip712::encode_uint(value), encoded);
+    }
+
+    #[rstest]
+    #[case(false, hex!("0000000000000000000000000000000000000000000000000000000000000000"))]
+    #[case(true, hex!("0000000000000000000000000000000000000000000000000000000000000001"))]
+    fn encode_bool(#[case] value: bool, #[case] encoded: Hash) {
+        assert_eq!(Eip712::encode_bool(value), encoded);
+    }
+
+    #[rstest]
+    fn encode_array() {
+        // empty array is encoded as keccak256 of empty input
+        assert_eq!(
+            Eip712::encode_array([]),
+            hex!("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"),
+        );
+
+        // known-answer vector (cross-checked against ethers):
+        // keccak256(keccak256("wallet.near") ‖ keccak256("v1.signer"))
+        assert_eq!(
+            Eip712::encode_array(["wallet.near", "v1.signer"].map(Eip712::encode_bytes)),
+            hex!("b6d2f824e6d61dbb48dede311263a3b2ae0915082ca066a234428bcd1ce7674b"),
+        );
+    }
+
+    #[rstest]
+    fn type_hash() {
+        // keccak256("Mail(string contents)")
+        assert_eq!(
+            Eip712::type_hash(MAIL_TYPE),
+            hex!("391581b66dfce93075def2f759ecf34a96f4b25b7efdd0b492e207d2ed9fbc76"),
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn sign_recover() {
+        let signer = SigningKey::generate();
+
+        let struct_hash = Eip712::hash_struct(
+            &Eip712::type_hash(MAIL_TYPE),
+            [Eip712::encode_bytes("Hello world!")],
+        );
+        let domain_separator = DOMAIN.separator();
+
+        let (signature, recovery_id) = RecoverableSigner::<Secp256k1>::sign_recoverable(
+            &signer,
+            &Eip712::prehash(&domain_separator, &struct_hash),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            Eip712::recover(&domain_separator, &struct_hash, &signature, recovery_id).as_ref(),
+            Some(signer.verifying_key()),
+            "can't recover signer's public key",
+        );
+    }
+}


### PR DESCRIPTION
Re-implementation of #325 on top of the NEP-641 reference implementation that landed in #335, adapted to the current wallet-contract architecture (`SignatureSchema::verify_request_msg()`/`verify_offchain_msg()`, NEP-641 `OffchainMessage`/`JsonPayload`).

Adds an EIP-712 (`eth_signTypedData_v4`) wallet-contract variant, so any Ethereum wallet (MetaMask, WalletConnect, Ledger) can be the sole key of a NEAR wallet-contract account — with **clear signing** preserved: the wallet displays the structure being authorized, never an opaque digest.

## Typed data

All types live under the same domain; the two signable messages are separated by their primary type:

```
EIP712Domain(string name,string version)
  name = "NEAR Wallet Contract", version = "1"

WalletRequest(string chainId,string signerId,uint32 nonce,string createdAt,uint32 timeoutSecs,WalletOp[] internal,NearPromise[] external,bool payForGas)
  WalletOp(string op,string payload)
  NearPromise(string receiverId,string refundTo,NearAction[] actions)
  NearAction(string action,string payload)

WalletAuth(string chainId,string signerId,string[] path,string timestamp,string payload)
```

The request contents are **unpacked** into typed structures: each wallet operation and each promise (with its actions) is an EIP-712 struct of its own, so the wallet renders them structurally — receivers, refund targets and action kinds are first-class members — instead of one opaque JSON blob. Only the leaf `payload`s remain JSON strings. `payForGas` sits at the end of the member list and MAY be omitted from the JSON representation (defaults to `false`); EIP-712 itself has no optional members, so it always remains part of the signed type.

`WalletAuth` mirrors the NEP-641 [`OffchainMessage`](https://github.com/near/NEPs/pull/641) field-for-field — including the bottom-up resolution `path` as a native EIP-712 `string[]`, so the wallet renders the delegation chain to the user as a list rather than an opaque blob.

```json
{
  "primaryType": "WalletRequest",
  "domain": { "name": "NEAR Wallet Contract", "version": "1" },
  "message": {
    "chainId": "mainnet",
    "signerId": "0se5eba21e8f191e1880e453794bc551dfa50a3419",
    "nonce": 44,
    "createdAt": "2026-07-16T12:34:56.789Z",
    "timeoutSecs": 300,
    "internal": [
      { "op": "add_extension", "payload": "{\"account_id\":\"extension.near\"}" }
    ],
    "external": [
      {
        "receiverId": "bob.near",
        "refundTo": "alice.near",
        "actions": [
          { "action": "transfer", "payload": "{\"deposit\":\"1000000000000000000000000\"}" }
        ]
      }
    ],
    "payForGas": false
  }
}
```

## How the display is enforced

The contract does not trust what the client claims to have displayed: it checks **every** member of the signed typed data against the message it is about to act upon (`Eip712RequestMessage::matches()` / `Eip712AuthMessage::matches()`), so a proof whose typed data says anything other than the message is rejected. Leaf `payload`s are compared *semantically* — parsed, then compared as JSON values — so clients are free to pretty-print them for display without breaking verification. The comparison is strict about the field set though: any extra field the contract would silently ignore invalidates the proof, so the wallet can never display more than what gets executed.

Tests cover this per field: tampering with any one of `chainId`, `signerId`, `nonce`, `createdAt`, `timeoutSecs`, `internal`, `external` (incl. `receiverId` and `refundTo` alone), `payForGas` (and the auth analogues `chainId`, `signerId`, `path` — replaced/extended/cleared, `timestamp`, `payload`) makes the proof fail.

`payForGas` matters especially here: hash-based schemas bind it for free via the canonical digest, but a clear-signing schema compares fields explicitly, so it has to be a member of the typed data — otherwise a proof signed with `payForGas: false` would verify against a request that flips it on, and the wallet would pay for gas the signer never authorized.

Since this schema signs the *contents* rather than the canonical NEP-641 hash, `verify_offchain_msg()` binds all `OffchainMessage` fields (`chain_id`, `signer_id`, `path`, `timestamp`, `payload`) through the typed data instead — same replay protections (cross-network, cross-account, cross-context), different encoding.

## Identity: `0x` address in state

The contract stores the signer's **Ethereum address** (`EthAddress` = `keccak256(public_key)[12..32]`, rendered as `0x<hex>` by `w_public_key()`) instead of the public key, and derives it from the public key it recovers from each proof — so the proof still binds the key.

Ethereum wallets expose the address without any signing ceremony (`eth_requestAccounts`), while the public key can only be recovered from a signature. Since the NEP-616 deterministic `AccountId` commits to the initial state, a client that only knows the address can already derive which NEAR account it controls — one roundtrip less than a public-key-in-state design (test: `account_id_derivable_from_address_alone`). It also frees 44 bytes of the ZBA budget.

Address derivation is checked against an independent secp256k1 + keccak256 implementation, so wallets end up controlled by exactly the key behind the user's existing Ethereum address.

## Proof

`proof` is a JSON-serialized `SignedEip712`: the typed data `message` plus a recoverable 65-byte secp256k1 `signature` (`r ‖ s ‖ v`, `v` ∈ {0,1}) as `secp256k1:<base58>` — the same signature encoding used elsewhere in this repo. Ethereum wallets return `v` as 27/28, so clients normalize by subtracting 27. Verification is a single `ecrecover` host call (malleable signatures rejected), compared against the address in state.

## Changes

* **New crate** `defuse-eip712` (`crates/signatures/eip712`): EIP-712 hashing primitives (`type_hash`, `hash_struct`, `encode_bytes`, `encode_uint`, `encode_bool`, `encode_array` for array members like `string[]`, `0x19 0x01` prehash, secp256k1 `recover`), following `defuse-erc191`/`defuse-tip191`. Domain is `name`+`version` only (NEAR has no EVM chain id and account ids don't fit `address`; network and account are bound by the message itself).
* **New contract variant** `defuse-wallet-eip712` (`contracts/wallet/signatures/eip712`): `WalletEip712` schema, `wallet-eip712` contract standard, typed-data types, `EthAddress`, and `WalletEip712Signer` implementing the SDK's `WalletSigner` (both `sign_request_msg()` and `sign_offchain_msg()`, so it plugs into the existing NEP-641 `RpcResolver` flow unchanged).
* Workspace members/deps, `Makefile` `CONTRACT_CRATES`, wallet README.

## Tests

* `defuse-eip712`: domain-separator, type-hash, uint/bool/array-encoding known-answer vectors (cross-checked against `ethers`), sign/recover round-trip.
* `defuse-wallet-eip712`: type-hash vectors for both primary types, `EthAddress` derivation/parsing vectors, account id derivable from the address alone, sign→verify round-trips for `w_execute_signed` and `w_resolve_auth`, 17 per-field tamper cases, cross-type replay (a request proof must not resolve an authorization and vice versa), wrong address, malformed/bare/other-curve proofs.
* Shared JSON fixtures `tests/fixtures/eip712-wallet-message.json` (4 request + 3 auth vectors, each with the canonical message, the `eth_signTypedData_v4` message, its prehash and the on-chain proof) pinning the wire format for cross-implementation clients. All prehashes are byte-identical to `ethers.TypedDataEncoder.hash()` and all proof signatures byte-identical to `ethers.Wallet.signTypedData()` with the same key (v normalized 27/28 → 0/1) — including the nested struct-array encoding (`WalletOp[]`/`NearPromise[]`/`NearAction[]`) and the `string[] path` encoding.

Checked: `cargo clippy --workspace --all-targets --all-features`, `cargo fmt --all --check`, `taplo format --check`, `cargo near build non-reproducible-wasm --locked --no-default-features --features=contract --abi-features=abi,contract`, `cargo test -p defuse-eip712 -p defuse-wallet-eip712 --all-features`. No sandbox test added: the shared `w_execute_signed`/`w_resolve_auth` paths are already covered by the existing suite, and this variant only swaps signature verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9K9KYrZXSmX69QxHRBqzi
