### PR TITLE
test(nep641): add canonical test vectors for OffchainMessage hashing

### DIFF
--- a/crates/signatures/nep641/Cargo.toml
+++ b/crates/signatures/nep641/Cargo.toml
@@ -109,6 +109,7 @@ resolver = [
 [dev-dependencies]
 defuse-nep641 = { path = ".", features = ["abi", "borsh", "digest", "serde", "near-kit", "resolver", "tracing"] }
 
+hex.workspace = true
 hex-literal.workspace = true
 near-kit = { workspace = true, features = ["sandbox"] }
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/signatures/nep641/README.md
+++ b/crates/signatures/nep641/README.md
@@ -1,0 +1,10 @@
+# NEP-641: Offchain Authorizations for Smart-Contracts
+
+## Test vectors
+
+[`vectors/offchain_message.json`](vectors/offchain_message.json) contains canonical
+[`OffchainMessage`](src/message.rs) hashes for implementations in other languages to check
+against. Every vector holds the message fields along with the expected, hex-encoded
+`SHA3_256("NEAR_NEP641_OFFCHAIN_MESSAGE/V1" || borsh(message))` digest.
+
+The vectors are asserted by this crate's test suite, so they cannot drift from the implementation.

--- a/crates/signatures/nep641/src/message.rs
+++ b/crates/signatures/nep641/src/message.rs
@@ -354,3 +354,48 @@ const _: () = {
         }
     }
 };
+
+#[cfg(all(test, feature = "borsh", feature = "digest", feature = "json"))]
+mod tests {
+    use super::*;
+
+    /// Canonical test vectors, published for implementations in other languages.
+    const VECTORS: &str = include_str!("../vectors/offchain_message.json");
+
+    #[derive(::serde::Deserialize)]
+    struct TestVectors {
+        domain_separator: String,
+        vectors: Vec<TestVector>,
+    }
+
+    #[derive(::serde::Deserialize)]
+    struct TestVector {
+        name: String,
+        message: OffchainMessage,
+        hash: String,
+    }
+
+    #[test]
+    fn offchain_message_hash_vectors() {
+        let TestVectors {
+            domain_separator,
+            vectors,
+        } = serde_json::from_str(VECTORS).expect("invalid test vectors");
+
+        assert_eq!(
+            domain_separator.as_bytes(),
+            OffchainMessage::DOMAIN_SEPARATOR,
+            "domain separator drifted from the test vectors",
+        );
+        assert!(!vectors.is_empty(), "no test vectors");
+
+        for TestVector {
+            name,
+            message,
+            hash,
+        } in vectors
+        {
+            assert_eq!(hex::encode(message.hash()), hash, "vector '{name}'");
+        }
+    }
+}

--- a/crates/signatures/nep641/vectors/offchain_message.json
+++ b/crates/signatures/nep641/vectors/offchain_message.json
@@ -1,0 +1,66 @@
+{
+  "domain_separator": "NEAR_NEP641_OFFCHAIN_MESSAGE/V1",
+  "algorithm": "SHA3_256(domain_separator || borsh(message))",
+  "vectors": [
+    {
+      "name": "empty_path",
+      "description": "Top-level authorization: the message is signed for the signer itself.",
+      "message": {
+        "chain_id": "mainnet",
+        "signer_id": "wallet.near",
+        "path": [],
+        "timestamp": "2026-08-05T07:28:00Z",
+        "payload": "Hello, Near!"
+      },
+      "hash": "d74f6c10967f3458aecc8ae11e5feef032ddf73df20c465a3ed4690ddf62dafa"
+    },
+    {
+      "name": "single_resolver_path",
+      "description": "One resolver hop, i.e. the top-level resolver is the only element of the path.",
+      "message": {
+        "chain_id": "mainnet",
+        "signer_id": "extension.near",
+        "path": ["wallet.near"],
+        "timestamp": "2026-08-05T07:28:00.123456789Z",
+        "payload": "Hello, Near!"
+      },
+      "hash": "ac9fc5df2a1da51c4e0446185c8e5b58b65f37d12c544d144fa8f026239962ae"
+    },
+    {
+      "name": "nested_resolver_path",
+      "description": "Two resolver hops, ordered bottom-top: the top-level resolver comes last.",
+      "message": {
+        "chain_id": "mainnet",
+        "signer_id": "extension.near",
+        "path": ["wallet.near", "v1.signer"],
+        "timestamp": "2026-08-05T07:28:00.123456789Z",
+        "payload": "Hello, Near!"
+      },
+      "hash": "039f8afb4ef2d76c621d3952f214bd2a080ce977ef351d52ff65a090eebbf72c"
+    },
+    {
+      "name": "subsecond_trailing_zeros",
+      "description": "Subseconds with trailing zeros, spelled out to full nanosecond precision.",
+      "message": {
+        "chain_id": "mainnet",
+        "signer_id": "wallet.near",
+        "path": [],
+        "timestamp": "2026-08-05T07:28:00.500000000Z",
+        "payload": "Hello, Near!"
+      },
+      "hash": "9f78988357a3ddb1bf6db6b1d13de12054e1baa26e055361a62bf8319e0d5129"
+    },
+    {
+      "name": "subsecond_trailing_zeros_omitted",
+      "description": "The same instant as `subsecond_trailing_zeros` with trailing zeros omitted. The timestamp is hashed as an integer number of nanoseconds, so both spellings MUST produce the same hash.",
+      "message": {
+        "chain_id": "mainnet",
+        "signer_id": "wallet.near",
+        "path": [],
+        "timestamp": "2026-08-05T07:28:00.5Z",
+        "payload": "Hello, Near!"
+      },
+      "hash": "9f78988357a3ddb1bf6db6b1d13de12054e1baa26e055361a62bf8319e0d5129"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a published set of canonical test vectors for `OffchainMessage` hashing, plus a test asserting the implementation reproduces them.

Why: I am implementing the TypeScript resolver that the NEP lists as TBD, and there was no published conformance suite to check against. In the forum thread a wallet team specifically asked for shared cross-language fixtures in a commonly referenced location, on the grounds that cross-language consistency matters here and downstream implementations should not each invent their own.

These sit next to the code that defines them rather than in a downstream package, and the accompanying test means they cannot drift from the implementation.

Coverage includes empty and non-empty `path`, subsecond timestamps with and without trailing zeros, and the existing doctest cases.

Forum discussion: https://gov.near.org/t/building-the-typescript-resolver-for-nep-641-currently-listed-as-tbd/42479

Happy to change the format or location if the crate would prefer something different.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for NEP-641 off-chain authorization test vectors and message digest formatting.

* **Tests**
  * Added validation for published off-chain message hash vectors, including domain separators and message variants.
  * Added coverage for empty, single-hop, nested resolver paths, and equivalent timestamps with different trailing-zero formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->